### PR TITLE
feat(resolver)!: Support different resolvers for modules and providers

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -33,7 +33,8 @@ const (
 
 	HomeDirectoryFlag = "home-dir"
 
-	StorageResolverFlag = "storage-resolver"
+	ModulesStorageResolverFlag   = "modules-storage-resolver"
+	ProvidersStorageResolverFlag = "providers-storage-resolver"
 
 	S3BucketNameFlag      = "s3-bucket-name"
 	S3BucketRegionFlag    = "s3-bucket-region"
@@ -121,8 +122,14 @@ var flags = map[string]cli.Flag{
 		DefaultValue: "~/.terralist.d",
 	},
 
-	StorageResolverFlag: &cli.StringFlag{
-		Description:  "The storage resolver.",
+	ModulesStorageResolverFlag: &cli.StringFlag{
+		Description:  "The modules storage resolver.",
+		Choices:      []string{"proxy", "local", "s3"},
+		DefaultValue: "proxy",
+	},
+
+	ProvidersStorageResolverFlag: &cli.StringFlag{
+		Description:  "The providers storage resolver.",
 		Choices:      []string{"proxy", "local", "s3"},
 		DefaultValue: "proxy",
 	},

--- a/example.yaml
+++ b/example.yaml
@@ -23,7 +23,8 @@ sqlite-path: "terralist.db"
 
 home-dir: "~/.terralist.d"
 
-storage-resolver: "s3"
+modules-storage-resolver: "s3"
+providers-storage-resolver: "proxy"
 
 s3-bucket-name: "<< YOUR_S3_BUCKET_NAME >>"
 s3-bucket-region: "<< S3_BUCKET_REGION >>"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -41,10 +41,11 @@ type Server struct {
 type Config struct {
 	RunningMode string
 
-	Database database.Engine
-	Provider auth.Provider
-	Resolver storage.Resolver
-	Store    session.Store
+	Database          database.Engine
+	Provider          auth.Provider
+	ModulesResolver   storage.Resolver
+	ProvidersResolver storage.Resolver
+	Store             session.Store
 }
 
 func NewServer(userConfig UserConfig, config Config) (*Server, error) {
@@ -115,7 +116,7 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	moduleRepository := &repositories.DefaultModuleRepository{
 		Database: config.Database,
-		Resolver: config.Resolver,
+		Resolver: config.ModulesResolver,
 	}
 
 	moduleService := &services.DefaultModuleService{


### PR DESCRIPTION
This PR removes the `storage-resolver` flag and adds the `modules-storage-resolver` and `providers-storage-resolver` flags. 
This feature allows the user to use different resolvers for modules and providers.

_Note_: This feature does not allow multiple instances of the same resolver (e.g. different S3 buckets for modules and providers).