### PR TITLE
feat(database): Add MySQL support

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -22,6 +22,13 @@ const (
 	PostgreSQLPortFlag     = "postgres-port"
 	PostgreSQLDatabaseFlag = "postgres-database"
 
+	MySQLURLFlag      = "mysql-url"
+	MySQLUsernameFlag = "mysql-username"
+	MySQLPasswordFlag = "mysql-password"
+	MySQLHostFlag     = "mysql-host"
+	MySQLPortFlag     = "mysql-port"
+	MySQLDatabaseFlag = "mysql-database"
+
 	OAuthProviderFlag = "oauth-provider"
 
 	// GitHub OAuth Flags
@@ -76,7 +83,7 @@ var flags = map[string]cli.Flag{
 
 	DatabaseBackendFlag: &cli.StringFlag{
 		Description:  "The database backend.",
-		Choices:      []string{"sqlite", "postgresql"},
+		Choices:      []string{"sqlite", "postgresql", "mysql"},
 		DefaultValue: "sqlite",
 	},
 
@@ -100,6 +107,25 @@ var flags = map[string]cli.Flag{
 		Description: "The port on which the PostgreSQL database listens.",
 	},
 	PostgreSQLDatabaseFlag: &cli.StringFlag{
+		Description: "The schema name on which application data should be stored.",
+	},
+
+	MySQLURLFlag: &cli.StringFlag{
+		Description: "The URL that can be used to connect to MySQL database.",
+	},
+	MySQLUsernameFlag: &cli.StringFlag{
+		Description: "The username that can be used to authenticate to MySQL database.",
+	},
+	MySQLPasswordFlag: &cli.StringFlag{
+		Description: "The password that can be used to authenticate to MySQL database.",
+	},
+	MySQLHostFlag: &cli.StringFlag{
+		Description: "The host where the MySQL database can be found.",
+	},
+	MySQLPortFlag: &cli.IntFlag{
+		Description: "The port on which the MySQL database listens.",
+	},
+	MySQLDatabaseFlag: &cli.StringFlag{
 		Description: "The schema name on which application data should be stored.",
 	},
 

--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -14,6 +14,7 @@ import (
 	"terralist/pkg/cli"
 	"terralist/pkg/database"
 	dbFactory "terralist/pkg/database/factory"
+	"terralist/pkg/database/mysql"
 	"terralist/pkg/database/postgresql"
 	"terralist/pkg/database/sqlite"
 	"terralist/pkg/session"
@@ -192,6 +193,15 @@ func (s *Command) run() error {
 			Hostname: flags[PostgreSQLHostFlag].(*cli.StringFlag).Value,
 			Port:     flags[PostgreSQLPortFlag].(*cli.IntFlag).Value,
 			Name:     flags[PostgreSQLDatabaseFlag].(*cli.StringFlag).Value,
+		})
+	case "mysql":
+		db, err = dbFactory.NewDatabase(database.MYSQL, &mysql.Config{
+			URL:      flags[MySQLURLFlag].(*cli.StringFlag).Value,
+			Username: flags[MySQLUsernameFlag].(*cli.StringFlag).Value,
+			Password: flags[MySQLPasswordFlag].(*cli.StringFlag).Value,
+			Hostname: flags[MySQLHostFlag].(*cli.StringFlag).Value,
+			Port:     flags[MySQLPortFlag].(*cli.IntFlag).Value,
+			Name:     flags[MySQLDatabaseFlag].(*cli.StringFlag).Value,
 		})
 	}
 	if err != nil {

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -42,6 +42,12 @@ Terralist also supports reading the environment at run-time. For example, if you
 | `postgres-username`          | string | no       | `n/a`                   | The username that can be used to authenticate to PostgreSQL database. |
 | `postgres-password`          | string | no       | `n/a`                   | The password that can be used to authenticate to PostgreSQL database. |
 | `postgres-database`          | string | no       | `n/a`                   | The schema name on which application data should be stored.           |
+| `mysql-url`                  | string | no       | `n/a`                   | The URL that can be used to connect to MySQL database.                |
+| `mysql-host`                 | string | no       | `n/a`                   | The host where the MySQL database can be found.                       |
+| `mysql-port`                 | int    | no       | `n/a`                   | The port on which the MySQL database listens.                         |
+| `mysql-username`             | string | no       | `n/a`                   | The username that can be used to authenticate to MySQL database.      |
+| `mysql-password`             | string | no       | `n/a`                   | The password that can be used to authenticate to MySQL database.      |
+| `mysql-database`             | string | no       | `n/a`                   | The schema name on which application data should be stored.           |
 | `sqlite-path`                | string | no       | `n/a`                   | The path to the SQLite database.                                      |
 | `session-store`              | string | no       | `cookie`                | The session store backend.                                            |
 | `cookie-secret`              | string | no       | `n/a`                   | The secret to use for cookie encryption.                              |
@@ -78,6 +84,10 @@ sqlite-path: "terralist.db"
 
 # database-backend: "postgresql"
 # postgres-url: "${DATABASE_URL:postgres://admin:admin@localhost:5678/public}"
+
+# database-backend: "mysql"
+# mysql-url must have parseTime=true
+# mysql-url: "admin:admin@tcp(localhost:3306)/terralist?parseTime=true"
 
 modules-storage-resolver: "s3"
 providers-storage-resolver: "proxy"

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -86,8 +86,7 @@ sqlite-path: "terralist.db"
 # postgres-url: "${DATABASE_URL:postgres://admin:admin@localhost:5678/public}"
 
 # database-backend: "mysql"
-# mysql-url must have parseTime=true
-# mysql-url: "admin:admin@tcp(localhost:3306)/terralist?parseTime=true"
+# mysql-url: "admin:admin@tcp(localhost:3306)/terralist"
 
 modules-storage-resolver: "s3"
 providers-storage-resolver: "proxy"

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/goccy/go-json v0.9.7 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
@@ -73,6 +74,7 @@ require (
 	google.golang.org/genproto v0.0.0-20221024183307-1bc688fe9f3e // indirect
 	google.golang.org/grpc v1.50.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gorm.io/driver/mysql v1.4.4 // indirect
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -145,6 +145,8 @@ github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/j
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.10.0 h1:I7mrTYv78z8k8VXa/qJlOlEXn/nBh+BF8dHX5nt/dr0=
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/goccy/go-json v0.9.7 h1:IcB+Aqpx/iMHu5Yooh7jEzJk1JZ7Pjtmys2ukPr7EeM=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
@@ -992,10 +994,13 @@ gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gorm.io/driver/mysql v1.4.4 h1:MX0K9Qvy0Na4o7qSC/YI7XxqUw5KDw01umqgID+svdQ=
+gorm.io/driver/mysql v1.4.4/go.mod h1:BCg8cKI+R0j/rZRQxeKis/forqRwRSYOR8OM3Wo6hOM=
 gorm.io/driver/postgres v1.4.5 h1:mTeXTTtHAgnS9PgmhN2YeUbazYpLhUI1doLnw42XUZc=
 gorm.io/driver/postgres v1.4.5/go.mod h1:GKNQYSJ14qvWkvPwXljMGehpKrhlDNsqYRr5HnYGncg=
 gorm.io/driver/sqlite v1.4.3 h1:HBBcZSDnWi5BW3B3rwvVTc510KGkBkexlOg0QrmLUuU=
 gorm.io/driver/sqlite v1.4.3/go.mod h1:0Aq3iPO+v9ZKbcdiz8gLWRw5VOPcBOPUQJFLq5e2ecI=
+gorm.io/gorm v1.23.8/go.mod h1:l2lP/RyAtc1ynaTjFksBde/O8v9oOGIApu2/xRitmZk=
 gorm.io/gorm v1.24.0/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=
 gorm.io/gorm v1.24.1-0.20221019064659-5dd2bb482755 h1:7AdrbfcvKnzejfqP5g37fdSZOXH/JvaPIzBIHTOqXKk=
 gorm.io/gorm v1.24.1-0.20221019064659-5dd2bb482755/go.mod h1:DVrVomtaYTbqs7gB/x2uVvqnXzv0nqjB396B8cG4dBA=

--- a/pkg/database/creator.go
+++ b/pkg/database/creator.go
@@ -3,6 +3,7 @@ package database
 const (
 	SQLITE = iota
 	POSTGRESQL
+	MYSQL
 )
 
 type Backend = int

--- a/pkg/database/factory/factory.go
+++ b/pkg/database/factory/factory.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"terralist/pkg/database"
+	"terralist/pkg/database/mysql"
 	"terralist/pkg/database/postgresql"
 	"terralist/pkg/database/sqlite"
 )
@@ -23,6 +24,8 @@ func NewDatabase(backend database.Backend, config database.Configurator) (databa
 		creator = &sqlite.Creator{}
 	case database.POSTGRESQL:
 		creator = &postgresql.Creator{}
+	case database.MYSQL:
+		creator = &mysql.Creator{}
 	default:
 		return nil, fmt.Errorf("unrecognized backend type")
 	}

--- a/pkg/database/mysql/config.go
+++ b/pkg/database/mysql/config.go
@@ -1,0 +1,60 @@
+package mysql
+
+import (
+	"fmt"
+	"net/url"
+)
+
+// Config implements database.Configurator interface and
+// handles the configuration parameters of the mysql database
+type Config struct {
+	Username string // the account username
+	Password string // the account password
+	Hostname string // the hostname where the mysql server is hosted
+	Port     int    // the port on which the server can be accessed
+	Name     string // the database name
+
+	// The database URL can be used to establish the connection without specifying
+	// other credentials
+	URL string
+}
+
+func (t *Config) SetDefaults() {}
+
+func (t *Config) Validate() error {
+	connectionWithParts := !(t.Username == "" || t.Password == "" || t.Hostname == "" || t.Port == 0 || t.Name == "")
+	connectionWithURL := !(t.URL == "")
+
+	if !connectionWithParts && !connectionWithURL {
+		return fmt.Errorf("no method for connection was provided")
+	}
+
+	if t.URL != "" {
+		pu, err := url.Parse(t.URL)
+		if err != nil {
+			return fmt.Errorf("cannot parse connection url: %w", err)
+		}
+
+		// https://github.com/go-sql-driver/mysql#timetime-support
+		if pu.Query().Get("parseTime") != "true" {
+			return fmt.Errorf("mysql: connection url must include property parseTime=true")
+		}
+	}
+
+	return nil
+}
+
+func (t *Config) DSN() string {
+	if t.URL != "" {
+		return t.URL
+	}
+
+	return fmt.Sprintf(
+		"%s:%s@tcp(%s:%d)/%s?parseTime=true",
+		t.Username,
+		t.Password,
+		t.Hostname,
+		t.Port,
+		t.Name,
+	)
+}

--- a/pkg/database/mysql/creator.go
+++ b/pkg/database/mysql/creator.go
@@ -1,0 +1,49 @@
+package mysql
+
+import (
+	"fmt"
+	"sync"
+
+	"terralist/pkg/database"
+	"terralist/pkg/database/logger"
+
+	"gorm.io/driver/mysql"
+	"gorm.io/gorm"
+)
+
+type Creator struct{}
+
+var (
+	lock = &sync.Mutex{}
+)
+
+func (t *Creator) New(config database.Configurator) (database.Engine, error) {
+	lock.Lock()
+	defer lock.Unlock()
+
+	cfg, ok := config.(*Config)
+	if !ok {
+		return nil, fmt.Errorf("wrong database configuration")
+	}
+
+	dsn := cfg.DSN()
+
+	db, err := gorm.Open(mysql.New(mysql.Config{
+		DSN:                       dsn,
+		DefaultStringSize:         256,   // default size for string fields
+		DisableDatetimePrecision:  true,  // disable datetime precision, which not supported before MySQL 5.6
+		DontSupportRenameIndex:    true,  // drop & create when rename index, rename index not supported before MySQL 5.7, MariaDB
+		DontSupportRenameColumn:   true,  // `change` when rename column, rename column not supported before MySQL 8, MariaDB
+		SkipInitializeWithVersion: false, // auto configure based on currently MySQL version
+	}), &gorm.Config{
+		Logger: &logger.Logger{},
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &database.DefaultEngine{
+		Handle: db.Debug(),
+	}, nil
+}


### PR DESCRIPTION
This will add MySQL support. Basically it's copy/paste of PostgreSQL code.
MySQL cannot have TEXT fields as unique indexes, so I've limited Name to 255 characters and UUID to 36. Apparently PostgreSQL/SQLite can work with it too, but please let me know if there are some concerns.
And mysql-url must have parseTime=true (https://github.com/go-sql-driver/mysql#timetime-support)