### PR TITLE
fix: MySQL data too long for large strings

### DIFF
--- a/internal/server/models/authority/key.go
+++ b/internal/server/models/authority/key.go
@@ -10,8 +10,8 @@ type Key struct {
 	entity.Entity
 	AuthorityID    uuid.UUID
 	KeyId          string `gorm:"not null"`
-	AsciiArmor     string `gorm:"not null"`
-	TrustSignature string `gorm:"not null"`
+	AsciiArmor     string `gorm:"size:10000,not null"`
+	TrustSignature string `gorm:"size:10000,not null"`
 }
 
 func (Key) TableName() string {


### PR DESCRIPTION
Fixes #109.

During the investigation, I analyzed two possible solutions:
- Increasing the size of the string (the current one);
  ```go
  AsciiArmor     string `gorm:"size:10000,not null"`
  TrustSignature string `gorm:"size:10000,not null"`
  ```
- Changing the column type to `text`;
  ```go
  AsciiArmor     string `gorm:"type:text,not null"`
  TrustSignature string `gorm:"type:text,not null"`
  ```

Both solutions work fine with the currently supported backends (PostgreSQL, MySQL, SQLite). 

I kept the first option because it's backend-agnostic and lets gorm choose which backend-specific type is more appropriate for the given size. For example, in this scenario, gorm picks `longtext` (max. length 2<sup>32</sup> − 1) for MySQL, even though `text` (max. length 2<sup>16</sup> - 1) is enough; for PostgreSQL and SQLite, everything is the same as before.

I set the upper limit to 10.000 because it's more than enough space for a gpg public key (the largest one I could find had less than 8.000 characters).