### PR TITLE
fix: Take reference of loop variables properly

### DIFF
--- a/internal/server/repositories/authority.go
+++ b/internal/server/repositories/authority.go
@@ -72,6 +72,7 @@ func (r *DefaultAuthorityRepository) FindAll(owner string) ([]*authority.Authori
 
 	asp := []*authority.Authority{}
 	for _, a := range as {
+		a := a
 		asp = append(asp, &a)
 	}
 


### PR DESCRIPTION
The loop variable is reassigned in each iteration. After the `for` loop ends, only the last value will be referenced.