### PR TITLE
feat: Add support for HTTPS

### DIFF
--- a/cmd/terralist/server/flags.go
+++ b/cmd/terralist/server/flags.go
@@ -11,6 +11,9 @@ const (
 
 	URLFlag = "url"
 
+	CertFileFlag = "cert-file"
+	KeyFileFlag  = "key-file"
+
 	DatabaseBackendFlag = "database-backend"
 
 	SQLitePathFlag = "sqlite-path"
@@ -86,6 +89,13 @@ var flags = map[string]cli.Flag{
 	URLFlag: &cli.StringFlag{
 		Description:  "The URL that Terralist is accessible from.",
 		DefaultValue: "http://localhost:5758",
+	},
+
+	CertFileFlag: &cli.StringFlag{
+		Description: "The path to the certificate file (pem format).",
+	},
+	KeyFileFlag: &cli.StringFlag{
+		Description: "The path to the certificate key file (pem format).",
 	},
 
 	DatabaseBackendFlag: &cli.StringFlag{
@@ -166,7 +176,7 @@ var flags = map[string]cli.Flag{
 		Description: "The GitLab OAuth Application client secret.",
 	},
 	GitLabHostFlag: &cli.StringFlag{
-		Description: "The GitLab host to use.",
+		Description:  "The GitLab host to use.",
 		DefaultValue: "gitlab.com",
 	},
 

--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -158,6 +158,8 @@ func (s *Command) run() error {
 		LogLevel:           flags[LogLevelFlag].(*cli.StringFlag).Value,
 		Port:               flags[PortFlag].(*cli.IntFlag).Value,
 		URL:                flags[URLFlag].(*cli.StringFlag).Value,
+		CertFile:           flags[CertFileFlag].(*cli.StringFlag).Value,
+		KeyFile:            flags[KeyFileFlag].(*cli.StringFlag).Value,
 		TokenSigningSecret: flags[TokenSigningSecretFlag].(*cli.StringFlag).Value,
 		OauthProvider:      flags[OAuthProviderFlag].(*cli.StringFlag).Value,
 		CustomCompanyName:  flags[CustomCompanyNameFlag].(*cli.StringFlag).Value,

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -27,6 +27,8 @@ Terralist also supports reading the environment at run-time. For example, if you
 | `log-level`                  | string | no       | `info`                  | The log level.                                                        |
 | `port`                       | int    | no       | `5758`                  | The port to bind to.                                                  |
 | `url`                        | string | no       | `http://localhost:5758` | The URL that Terralist is accessible from.                            |
+| `cert-file`                  | string | no       | `n/a`                   | The path to the certificate file (pem format).                        |
+| `key-file`                   | string | no       | `n/a`                   | "The path to the certificate key file (pem format).                   |
 | `token-signing-secret`       | string | yes      | `n/a`                   | The secret to use when signing authorization tokens.                  |
 | `oauth-provider`             | string | yes      | `n/a`                   | The OAuth 2.0 provider.                                               |
 | `gh-client-id`               | string | no       | `n/a`                   | The GitHub OAuth Application client ID.                               |

--- a/internal/server/config.go
+++ b/internal/server/config.go
@@ -4,6 +4,8 @@ type UserConfig struct {
 	LogLevel           string `mapstructure:"log-level"`
 	Port               int    `mapstructure:"port"`
 	URL                string `mapstructure:"url"`
+	CertFile           string `mapstructure:"cert-file"`
+	KeyFile            string `mapstructure:"key-file"`
 	TokenSigningSecret string `mapstructure:"token-signing-secret"`
 	OauthProvider      string `mapstructure:"oauth-provider"`
 	CustomCompanyName  string `mapstructure:"custom-company-name"`


### PR DESCRIPTION
This PR introduces support for HTTPS.

Terraform requires the registry to be served over HTTPS. Because of that, up until now, Terralist was forced to be placed behind a reverse proxy that handled the SSL certificate.