### PR TITLE
feat(web): Support Settings filtering on email address

### DIFF
--- a/web/src/routes.ts
+++ b/web/src/routes.ts
@@ -56,7 +56,6 @@ const isAuthorizedUser = () => {
       authorizedUsers[0] === '' ||
       authorizedUsers.includes(user.userName) ||
       authorizedUsers.includes(user.userEmail)
-      )
     );
   };
 };

--- a/web/src/routes.ts
+++ b/web/src/routes.ts
@@ -52,7 +52,12 @@ const isAuthorizedUser = () => {
     }
     const authorizedUsers =
       config.runtime.TERRALIST_AUTHORIZED_USERS.split(',');
-    return authorizedUsers[0] === '' || authorizedUsers.includes(user.userName);
+    return (
+      authorizedUsers[0] === '' ||
+      authorizedUsers.includes(user.userName) ||
+      authorizedUsers.includes(user.userEmail)
+      )
+    );
   };
 };
 


### PR DESCRIPTION
Currently, the web UI `isAuthorizedUser` method only looks at the `UserSession.userName` value. If you are using Google OAuth2/OIDC, this value is an integer most people will not know. The Typescript was updated to also check for the existence of `UserSession.userEmail` within the comma-separated list of values set in `TERRALIST_AUTHORIZED_USERS`.