### PR TITLE
fix: Prevent panic if oauth redirect endpoint receives no state

### DIFF
--- a/internal/server/controllers/login.go
+++ b/internal/server/controllers/login.go
@@ -159,6 +159,11 @@ func (c *DefaultLoginController) Subscribe(apis ...*gin.RouterGroup) {
 		code := ctx.Query("code")
 		state := ctx.Query("state")
 
+		if code == "" || state == "" {
+			ctx.AbortWithStatus(http.StatusBadRequest)
+			return
+		}
+
 		r, err := oauth.Payload(state).ToRequest(c.EncryptSalt)
 		if err != nil {
 			ctx.Redirect(


### PR DESCRIPTION
Fixes #606.