### PR TITLE
fix: Properly set path for default SQLite location

### DIFF
--- a/cmd/terralist/server/server.go
+++ b/cmd/terralist/server/server.go
@@ -211,6 +211,7 @@ func (s *Command) run() error {
 	case "sqlite":
 		db, err = dbFactory.NewDatabase(database.SQLITE, &sqlite.Config{ //nolint:forcetypeassert
 			Path: flags[SQLitePathFlag].(*cli.StringFlag).Value,
+			Home: userConfig.Home,
 		})
 	case "postgresql":
 		db, err = dbFactory.NewDatabase(database.POSTGRESQL, &postgresql.Config{ //nolint:forcetypeassert

--- a/pkg/database/sqlite/config.go
+++ b/pkg/database/sqlite/config.go
@@ -1,17 +1,44 @@
 package sqlite
 
+import (
+	"os"
+	"path/filepath"
+)
+
 // Config implements database.Configurator interface and
 // handles the default configuration parameters of the sqlite database.
 type Config struct {
 	Path string
+	Home string
 }
 
 func (c *Config) SetDefaults() {
-	if c.Path == "" {
-		c.Path = "storage.db"
+	if c.Path != "" {
+		return
 	}
+
+	c.Path = DefaultPath(c.Home)
 }
 
 func (c *Config) Validate() error {
 	return nil
+}
+
+// DefaultPath returns the default sqlite path for the given home directory.
+func DefaultPath(home string) string {
+	if home == "" {
+		home = os.Getenv("TERRALIST_HOME")
+	}
+
+	if home == "" {
+		if userHome, err := os.UserHomeDir(); err == nil {
+			home = userHome
+		}
+	}
+
+	if home == "" {
+		home = "."
+	}
+
+	return filepath.Join(home, "data", "storage.db")
 }

--- a/pkg/database/sqlite/config.go
+++ b/pkg/database/sqlite/config.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"os"
 	"path/filepath"
 )
 
@@ -26,19 +25,5 @@ func (c *Config) Validate() error {
 
 // DefaultPath returns the default sqlite path for the given home directory.
 func DefaultPath(home string) string {
-	if home == "" {
-		home = os.Getenv("TERRALIST_HOME")
-	}
-
-	if home == "" {
-		if userHome, err := os.UserHomeDir(); err == nil {
-			home = userHome
-		}
-	}
-
-	if home == "" {
-		home = "."
-	}
-
 	return filepath.Join(home, "data", "storage.db")
 }

--- a/pkg/database/sqlite/config_test.go
+++ b/pkg/database/sqlite/config_test.go
@@ -1,0 +1,79 @@
+package sqlite
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultPathUsesProvidedHome(t *testing.T) {
+	home := "/custom/home"
+	want := filepath.Join(home, "data", "storage.db")
+
+	if got := DefaultPath(home); got != want {
+		t.Fatalf("DefaultPath(%q) = %q, want %q", home, got, want)
+	}
+}
+
+func TestDefaultPathUsesEnvWhenHomeEmpty(t *testing.T) {
+	const envHome = "/env/terralist"
+
+	t.Setenv("TERRALIST_HOME", envHome)
+
+	got := DefaultPath("")
+	want := filepath.Join(envHome, "data", "storage.db")
+	if got != want {
+		t.Fatalf("DefaultPath(empty) = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultPathFallsBackToUserHome(t *testing.T) {
+	t.Setenv("TERRALIST_HOME", "")
+
+	userHome, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("could not determine user home dir: %v", err)
+	}
+
+	got := DefaultPath("")
+	want := filepath.Join(userHome, "data", "storage.db")
+	if got != want {
+		t.Fatalf("DefaultPath(empty) = %q, want %q", got, want)
+	}
+}
+
+func TestConfigSetDefaults(t *testing.T) {
+	const home = "/example/home"
+
+	cfg := &Config{Home: home}
+	cfg.SetDefaults()
+
+	want := filepath.Join(home, "data", "storage.db")
+	if cfg.Path != want {
+		t.Fatalf("Config.SetDefaults: got %q, want %q", cfg.Path, want)
+	}
+
+	preexisting := &Config{
+		Path: "/data/db.sqlite",
+		Home: home,
+	}
+	preexisting.SetDefaults()
+	if preexisting.Path != "/data/db.sqlite" {
+		t.Fatalf("Config.SetDefaults overwrote path: got %q, want %q", preexisting.Path, "/data/db.sqlite")
+	}
+}
+
+func TestConfigSetDefaultsHonorsExplicitPath(t *testing.T) {
+	const home = "/custom/home"
+	const explicit = "/tmp/terralist-data/storage.db"
+
+	cfg := &Config{
+		Path: explicit,
+		Home: home,
+	}
+
+	cfg.SetDefaults()
+	if cfg.Path != explicit {
+		t.Fatalf("Config.SetDefaults cleared explicit path: got %q, want %q", cfg.Path, explicit)
+	}
+}

--- a/pkg/database/sqlite/config_test.go
+++ b/pkg/database/sqlite/config_test.go
@@ -1,7 +1,6 @@
 package sqlite
 
 import (
-	"os"
 	"path/filepath"
 	"testing"
 )
@@ -15,28 +14,10 @@ func TestDefaultPathUsesProvidedHome(t *testing.T) {
 	}
 }
 
-func TestDefaultPathUsesEnvWhenHomeEmpty(t *testing.T) {
-	const envHome = "/env/terralist"
-
-	t.Setenv("TERRALIST_HOME", envHome)
-
+func TestDefaultPathAllowsEmptyHome(t *testing.T) {
 	got := DefaultPath("")
-	want := filepath.Join(envHome, "data", "storage.db")
-	if got != want {
-		t.Fatalf("DefaultPath(empty) = %q, want %q", got, want)
-	}
-}
+	want := filepath.Join("data", "storage.db")
 
-func TestDefaultPathFallsBackToUserHome(t *testing.T) {
-	t.Setenv("TERRALIST_HOME", "")
-
-	userHome, err := os.UserHomeDir()
-	if err != nil {
-		t.Fatalf("could not determine user home dir: %v", err)
-	}
-
-	got := DefaultPath("")
-	want := filepath.Join(userHome, "data", "storage.db")
 	if got != want {
 		t.Fatalf("DefaultPath(empty) = %q, want %q", got, want)
 	}


### PR DESCRIPTION
If `TERRALIST_SQLITE_PATH` is not set, then create the SQLite DB at `$TERRALIST_HOME/data/storage.db` instead of `/storage.db` which is the current default.