### PR TITLE
fix: Properly encode DB DSNs 

### DIFF
--- a/pkg/database/sqlite/config.go
+++ b/pkg/database/sqlite/config.go
@@ -1,6 +1,9 @@
 package sqlite
 
 import (
+	"fmt"
+	"net/url"
+	"os"
 	"path/filepath"
 )
 
@@ -16,14 +19,29 @@ func (c *Config) SetDefaults() {
 		return
 	}
 
-	c.Path = DefaultPath(c.Home)
+	c.Path = filepath.Join(c.Home, "data", "storage.db")
 }
 
 func (c *Config) Validate() error {
+	// Check if the directory exists and create it if it doesn't
+	if err := os.MkdirAll(filepath.Dir(c.Path), os.ModePerm); err != nil {
+		return fmt.Errorf("could not prepare sqlite directory: %w", err)
+	}
+
 	return nil
 }
 
-// DefaultPath returns the default sqlite path for the given home directory.
-func DefaultPath(home string) string {
-	return filepath.Join(home, "data", "storage.db")
+func (c *Config) DSN() string {
+	url := &url.URL{
+		Path: c.Path,
+	}
+
+	q := url.Query()
+
+	// See https://gitlab.com/cznic/sqlite/-/issues/47
+	q.Set("_time_format", "sqlite")
+
+	url.RawQuery = q.Encode()
+
+	return url.String()
 }

--- a/pkg/database/sqlite/config_test.go
+++ b/pkg/database/sqlite/config_test.go
@@ -1,31 +1,17 @@
 package sqlite
 
 import (
+	"database/sql"
+	"net/url"
+	"os"
 	"path/filepath"
 	"testing"
+
+	_ "modernc.org/sqlite/lib"
 )
 
-func TestDefaultPathUsesProvidedHome(t *testing.T) {
-	home := "/custom/home"
-	want := filepath.Join(home, "data", "storage.db")
-
-	if got := DefaultPath(home); got != want {
-		t.Fatalf("DefaultPath(%q) = %q, want %q", home, got, want)
-	}
-}
-
-func TestDefaultPathAllowsEmptyHome(t *testing.T) {
-	got := DefaultPath("")
-	want := filepath.Join("data", "storage.db")
-
-	if got != want {
-		t.Fatalf("DefaultPath(empty) = %q, want %q", got, want)
-	}
-}
-
-func TestConfigSetDefaults(t *testing.T) {
-	const home = "/example/home"
-
+func TestConfigSetDefaults_UsesHome(t *testing.T) {
+	home := t.TempDir()
 	cfg := &Config{Home: home}
 	cfg.SetDefaults()
 
@@ -33,28 +19,114 @@ func TestConfigSetDefaults(t *testing.T) {
 	if cfg.Path != want {
 		t.Fatalf("Config.SetDefaults: got %q, want %q", cfg.Path, want)
 	}
+}
 
-	preexisting := &Config{
-		Path: "/data/db.sqlite",
-		Home: home,
-	}
-	preexisting.SetDefaults()
-	if preexisting.Path != "/data/db.sqlite" {
-		t.Fatalf("Config.SetDefaults overwrote path: got %q, want %q", preexisting.Path, "/data/db.sqlite")
+func TestConfigSetDefaults_PreservesExplicitPath(t *testing.T) {
+	home := t.TempDir()
+	explicit := filepath.Join(home, "custom.db")
+	cfg := &Config{Path: explicit, Home: home}
+	cfg.SetDefaults()
+
+	if cfg.Path != explicit {
+		t.Fatalf("Config.SetDefaults cleared explicit path: got %q, want %q", cfg.Path, explicit)
 	}
 }
 
-func TestConfigSetDefaultsHonorsExplicitPath(t *testing.T) {
-	const home = "/custom/home"
-	const explicit = "/tmp/terralist-data/storage.db"
+func TestConfigValidate_CreatesDirectory(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "nested", "sub", "storage.db")
+	cfg := &Config{Path: path}
 
-	cfg := &Config{
-		Path: explicit,
-		Home: home,
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
 	}
 
-	cfg.SetDefaults()
-	if cfg.Path != explicit {
-		t.Fatalf("Config.SetDefaults cleared explicit path: got %q, want %q", cfg.Path, explicit)
+	dir := filepath.Dir(path)
+	st, err := os.Stat(dir)
+	if err != nil {
+		t.Fatalf("expected directory %q to exist: %v", dir, err)
+	}
+	if !st.IsDir() {
+		t.Fatalf("expected %q to be a directory", dir)
+	}
+}
+
+func TestConfigValidate_FailsWhenParentIsFile(t *testing.T) {
+	tmp := t.TempDir()
+	// Create a file where a directory is expected.
+	blocker := filepath.Join(tmp, "blocked")
+	if err := os.WriteFile(blocker, []byte("I block the path"), 0644); err != nil {
+		t.Fatalf("failed to create blocker file: %v", err)
+	}
+
+	// Use the file path as the parent directory for the DB path.
+	dbPath := filepath.Join(blocker, "storage.db")
+	cfg := &Config{Path: dbPath}
+	if err := cfg.Validate(); err == nil {
+		t.Fatalf("Validate should have failed when parent path is a file")
+	}
+}
+
+func TestConfigDSN_IncludesTimeFormatAndPath(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "storage.db")
+
+	cfg := &Config{Path: dbPath}
+	dsn := cfg.DSN()
+
+	u, err := url.Parse(dsn)
+	if err != nil {
+		t.Fatalf("failed to parse DSN %q: %v", dsn, err)
+	}
+
+	if u.Path != cfg.Path {
+		t.Fatalf("DSN path = %q, want %q", u.Path, cfg.Path)
+	}
+
+	q := u.Query()
+	if q.Get("_time_format") != "sqlite" {
+		t.Fatalf("DSN query _time_format = %q, want %q", q.Get("_time_format"), "sqlite")
+	}
+}
+
+// Integration test: ensure the sqlite driver can open the DSN and perform basic CRUD.
+func TestSQLiteDriver_ConnectAndWrite(t *testing.T) {
+	tmp := t.TempDir()
+	dbPath := filepath.Join(tmp, "integration.db")
+
+	cfg := &Config{Path: dbPath}
+	// Ensure parent dir exists
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate returned error: %v", err)
+	}
+
+	dsn := cfg.DSN()
+
+	db, err := sql.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("failed to open sqlite db with DSN %q: %v", dsn, err)
+	}
+	defer db.Close()
+
+	// Create table
+	_, err = db.Exec(`CREATE TABLE IF NOT EXISTS kv (k TEXT PRIMARY KEY, v TEXT);`)
+	if err != nil {
+		t.Fatalf("failed to create table: %v", err)
+	}
+
+	// Insert a row
+	_, err = db.Exec(`INSERT INTO kv(k, v) VALUES(?, ?)`, "foo", "bar")
+	if err != nil {
+		t.Fatalf("failed to insert row: %v", err)
+	}
+
+	// Read it back
+	var v string
+	err = db.QueryRow(`SELECT v FROM kv WHERE k = ?`, "foo").Scan(&v)
+	if err != nil {
+		t.Fatalf("failed to query row: %v", err)
+	}
+	if v != "bar" {
+		t.Fatalf("unexpected value from db: got %q, want %q", v, "bar")
 	}
 }

--- a/pkg/database/sqlite/creator.go
+++ b/pkg/database/sqlite/creator.go
@@ -2,9 +2,6 @@ package sqlite
 
 import (
 	"fmt"
-	"net/url"
-	"os"
-	"path/filepath"
 	"sync"
 
 	"terralist/pkg/database"
@@ -30,15 +27,7 @@ func (t *Creator) New(config database.Configurator) (database.Engine, error) {
 		return nil, fmt.Errorf("unsupported configurator: %T", config)
 	}
 
-	// See https://gitlab.com/cznic/sqlite/-/issues/47
-	dsn := cfg.Path
-	q := make(url.Values)
-	q.Set("_time_format", "sqlite")
-	dsn += "?" + q.Encode()
-
-	if err := os.MkdirAll(filepath.Dir(cfg.Path), os.ModePerm); err != nil {
-		return nil, fmt.Errorf("could not prepare sqlite directory: %w", err)
-	}
+	dsn := cfg.DSN()
 
 	db, err := gorm.Open(sqlite.Open(dsn), &gorm.Config{
 		Logger: &logger.Logger{},


### PR DESCRIPTION
This PR wraps the DSN builder for each database connector in `net/url.URL`. This ensures all dialectors connection strings are properly encoded before being forwarded to them.

Fixes #678.