### PR TITLE
feat: add comprehensive Prometheus metrics and monitoring

### DIFF
--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,3 +1,9 @@
 # User Guide
 
 The Terralist User Guide provides documentation for users of Terralist. Various guides to configuring and using Terralist can be find here.
+
+## Available Guides
+
+- [AWS S3 Bucket Configuration](aws-s3-bucket-configuration.md) - Configure S3 storage backend
+- [RBAC Configuration](rbac-configuration.md) - Set up role-based access control
+- [Monitoring and Observability](monitoring.md) - Prometheus metrics and monitoring setup

--- a/docs/user-guide/monitoring.md
+++ b/docs/user-guide/monitoring.md
@@ -1,0 +1,533 @@
+# Monitoring and Observability
+
+Terralist exposes Prometheus metrics to provide deep insights into registry operations, storage backend performance, and system health.
+
+## Metrics Endpoint
+
+Metrics are available at:
+
+```
+GET /metrics
+```
+
+This endpoint returns metrics in Prometheus format and can be scraped by Prometheus or compatible monitoring systems.
+
+## Available Metrics
+
+### Application Metrics
+
+#### Build Information
+
+```
+terralist_build_info{version="...", commit="...", build_time="..."}
+```
+
+Static metadata about the running Terralist instance.
+
+#### Uptime
+
+```
+terralist_uptime_seconds
+```
+
+Total seconds since Terralist started.
+
+#### Errors
+
+```
+terralist_errors_total{type="..."}
+```
+
+Total count of errors by type.
+
+---
+
+### Artifacts Metrics
+
+Track module and provider operations across authorities.
+
+#### Uploads
+
+```
+terralist_artifacts_uploaded_total{type="module|provider", authority="..."}
+```
+
+Total number of uploaded artifacts.
+
+**Example queries:**
+```promql
+# Upload rate per minute
+rate(terralist_artifacts_uploaded_total[5m])
+
+# Uploads by authority
+sum by (authority) (terralist_artifacts_uploaded_total)
+```
+
+#### Downloads
+
+```
+terralist_artifacts_downloaded_total{type="module|provider", authority="..."}
+```
+
+Total number of downloaded artifacts.
+
+**Example queries:**
+```promql
+# Most downloaded modules
+topk(10, sum by (authority) (terralist_artifacts_downloaded_total{type="module"}))
+```
+
+#### Deletions
+
+```
+terralist_artifacts_deleted_total{type="module|provider", authority="..."}
+```
+
+Total number of deleted artifacts.
+
+#### Current Artifact Count
+
+```
+terralist_artifacts_total{type="module|provider", authority="..."}
+```
+
+Current number of artifacts (gauge that increases with uploads, decreases with deletions).
+
+**Example queries:**
+```promql
+# Total artifacts in registry
+sum(terralist_artifacts_total)
+
+# Artifacts per authority
+sum by (authority, type) (terralist_artifacts_total)
+```
+
+---
+
+### Request Metrics
+
+#### Requests by Authority
+
+```
+terralist_requests_by_authority_total{authority="...", operation="upload|download|list"}
+```
+
+Total requests grouped by authority and operation type.
+
+**Example queries:**
+```promql
+# Request rate per authority
+rate(terralist_requests_by_authority_total[5m])
+
+# Most active authorities
+topk(5, sum by (authority) (rate(terralist_requests_by_authority_total[5m])))
+```
+
+---
+
+### API Keys Metrics
+
+```
+terralist_api_keys_total{authority="...", status="active|expired"}
+```
+
+Current number of API keys by authority and status.
+
+**Example queries:**
+```promql
+# Total active API keys
+sum(terralist_api_keys_total{status="active"})
+
+# Expired keys that need cleanup
+terralist_api_keys_total{status="expired"} > 0
+```
+
+---
+
+### Storage Backend Metrics
+
+Monitor the performance and health of storage backends (S3, Azure, GCS, Local).
+
+#### Operations
+
+```
+terralist_storage_operations_total{operation="upload|download|delete", backend="s3|azure|gcs|local", status="success|error"}
+```
+
+Total storage operations by type, backend, and status.
+
+**Example queries:**
+```promql
+# Error rate by backend
+rate(terralist_storage_operations_total{status="error"}[5m])
+
+# Success rate percentage
+sum(rate(terralist_storage_operations_total{status="success"}[5m])) 
+/ 
+sum(rate(terralist_storage_operations_total[5m])) * 100
+```
+
+#### Data Transfer
+
+```
+terralist_storage_bytes_total{operation="upload|download", backend="..."}
+```
+
+Total bytes transferred through storage operations.
+
+**Example queries:**
+```promql
+# Upload throughput (bytes/sec)
+rate(terralist_storage_bytes_total{operation="upload"}[5m])
+
+# Total data uploaded per backend
+sum by (backend) (terralist_storage_bytes_total{operation="upload"})
+```
+
+#### Operation Duration
+
+```
+terralist_storage_operation_duration_seconds{operation="...", backend="..."}
+```
+
+Histogram of storage operation durations.
+
+**Example queries:**
+```promql
+# P95 upload latency
+histogram_quantile(0.95, sum(rate(terralist_storage_operation_duration_seconds_bucket{operation="upload"}[5m])) by (le, backend))
+
+# P50 download latency by backend
+histogram_quantile(0.50, sum(rate(terralist_storage_operation_duration_seconds_bucket{operation="download"}[5m])) by (le, backend))
+
+# Slow operations (>5s)
+terralist_storage_operation_duration_seconds_bucket{le="5.0"} - terralist_storage_operation_duration_seconds_bucket{le="2.5"}
+```
+
+---
+
+### HTTP Metrics
+
+Standard HTTP metrics provided by Prometheus middleware.
+
+#### Request Duration
+
+```
+terralist_http_request_duration_seconds{method="GET|POST|PUT|DELETE", path="...", status="200|404|500"}
+```
+
+Histogram of HTTP request durations.
+
+#### Requests Total
+
+```
+terralist_http_requests_total{method="...", path="...", status="..."}
+```
+
+Total HTTP requests.
+
+#### Request Size
+
+```
+terralist_http_request_size_bytes{method="...", path="..."}
+```
+
+Histogram of HTTP request body sizes.
+
+#### Response Size
+
+```
+terralist_http_response_size_bytes{method="...", path="..."}
+```
+
+Histogram of HTTP response sizes.
+
+**Example queries:**
+```promql
+# Request rate per endpoint
+sum by (path) (rate(terralist_http_requests_total[5m]))
+
+# Error rate (4xx + 5xx)
+sum(rate(terralist_http_requests_total{status=~"4..|5.."}[5m]))
+
+# P99 response time
+histogram_quantile(0.99, sum(rate(terralist_http_request_duration_seconds_bucket[5m])) by (le))
+```
+
+---
+
+### Database Metrics
+
+Connection pool and query performance metrics.
+
+#### Active Connections
+
+```
+terralist_database_connections_active
+```
+
+Current number of active database connections.
+
+#### Idle Connections
+
+```
+terralist_database_connections_idle
+```
+
+Current number of idle database connections in the pool.
+
+#### Connections in Use
+
+```
+terralist_database_connections_in_use
+```
+
+Current number of connections actively executing queries.
+
+#### Wait Count
+
+```
+terralist_database_connections_wait_count_total
+```
+
+Total number of times a connection had to wait.
+
+#### Wait Duration
+
+```
+terralist_database_connections_wait_duration_seconds_total
+```
+
+Total time spent waiting for connections.
+
+**Example queries:**
+```promql
+# Connection pool utilization %
+(terralist_database_connections_in_use / terralist_database_connections_active) * 100
+
+# Average wait time
+rate(terralist_database_connections_wait_duration_seconds_total[5m]) 
+/ 
+rate(terralist_database_connections_wait_count_total[5m])
+```
+
+---
+
+## Prometheus Configuration
+
+Add Terralist to your `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: 'terralist'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['terralist:5758']
+    metrics_path: /metrics
+```
+
+---
+
+## Alerting Examples
+
+> **Note:** These are example alerts to get you started. Thresholds, severity levels, and time windows should be adjusted based on your specific workload, SLA requirements, and operational experience. Start with conservative thresholds and refine them based on actual production behavior to avoid alert fatigue.
+
+### Storage Backend Alerts
+
+#### High Storage Error Rate
+
+```yaml
+groups:
+  - name: terralist_storage
+    rules:
+      - alert: HighStorageErrorRate
+        expr: |
+          (
+            sum by (backend) (rate(terralist_storage_operations_total{status="error"}[5m]))
+            /
+            sum by (backend) (rate(terralist_storage_operations_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High storage error rate on {{ $labels.backend }} ({{ $value | humanizePercentage }})"
+          description: "Storage backend {{ $labels.backend }} has error rate above 5% for 5 minutes"
+```
+
+#### Slow Storage Operations
+
+```yaml
+      - alert: SlowStorageOperations
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le, backend, operation) (rate(terralist_storage_operation_duration_seconds_bucket[5m]))
+          ) > 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow {{ $labels.operation }} on {{ $labels.backend }} (P95: {{ $value | humanizeDuration }})"
+          description: "Storage {{ $labels.operation }} P95 latency exceeds 5s on {{ $labels.backend }}"
+
+      - alert: CriticallySlowStorageOperations
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le, backend, operation) (rate(terralist_storage_operation_duration_seconds_bucket[5m]))
+          ) > 30
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Critical storage latency on {{ $labels.backend }} (P95: {{ $value | humanizeDuration }})"
+          description: "Storage operations critically slow, may impact user experience"
+```
+
+#### Storage Backend Down
+
+```yaml
+      - alert: StorageBackendNoActivity
+        expr: |
+          (time() - max by (backend) (terralist_storage_operations_total)) > 3600
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "No storage activity on {{ $labels.backend }} for over 1 hour"
+          description: "Storage backend {{ $labels.backend }} may be unreachable or experiencing issues"
+```
+
+---
+
+### HTTP and API Alerts
+
+#### High HTTP Error Rate
+
+```yaml
+  - name: terralist_http
+    rules:
+      - alert: HighHTTPErrorRate
+        expr: |
+          (
+            sum(rate(terralist_http_requests_total{status=~"5.."}[5m]))
+            /
+            sum(rate(terralist_http_requests_total[5m]))
+          ) > 0.05
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "High HTTP 5xx error rate ({{ $value | humanizePercentage }})"
+          description: "More than 5% of requests returning 5xx errors"
+
+      - alert: HighHTTPClientErrorRate
+        expr: |
+          (
+            sum(rate(terralist_http_requests_total{status=~"4.."}[5m]))
+            /
+            sum(rate(terralist_http_requests_total[5m]))
+          ) > 0.20
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High HTTP 4xx error rate ({{ $value | humanizePercentage }})"
+          description: "More than 20% of requests returning 4xx errors, check authentication"
+```
+
+#### Slow HTTP Responses
+
+```yaml
+      - alert: SlowHTTPResponses
+        expr: |
+          histogram_quantile(0.95,
+            sum by (le, path) (rate(terralist_http_request_duration_seconds_bucket[5m]))
+          ) > 5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Slow responses on {{ $labels.path }} (P95: {{ $value | humanizeDuration }})"
+          description: "API endpoint {{ $labels.path }} responding slowly"
+```
+
+---
+
+### Database Alerts
+
+#### Connection Pool Exhaustion
+
+```yaml
+  - name: terralist_database
+    rules:
+      - alert: DatabaseConnectionPoolNearLimit
+        expr: |
+          (terralist_database_connections_in_use / terralist_database_connections_active) > 0.8
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Database connection pool {{ $value | humanizePercentage }} utilized"
+          description: "Connection pool usage above 80%, consider increasing pool size"
+
+      - alert: DatabaseConnectionPoolExhausted
+        expr: |
+          (terralist_database_connections_in_use / terralist_database_connections_active) > 0.95
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Database connection pool nearly exhausted ({{ $value | humanizePercentage }})"
+          description: "Immediate action required - connection pool at capacity"
+```
+
+#### High Connection Wait Times
+
+```yaml
+      - alert: HighDatabaseConnectionWaitTime
+        expr: |
+          rate(terralist_database_connections_wait_duration_seconds_total[5m])
+          /
+          rate(terralist_database_connections_wait_count_total[5m])
+          > 0.5
+        for: 10m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High database connection wait time ({{ $value | humanizeDuration }} avg)"
+          description: "Applications waiting too long for database connections"
+```
+
+---
+
+### System Health Alerts
+
+#### Service Down
+
+```yaml
+  - name: terralist_health
+    rules:
+      - alert: TerraListDown
+        expr: up{job="terralist"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "Terralist service is down"
+          description: "Terralist instance unreachable for 2 minutes"
+```
+
+#### High Error Count
+
+```yaml
+      - alert: HighApplicationErrorCount
+        expr: |
+          increase(terralist_errors_total[5m]) > 50
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "High application error count ({{ $value }} in 5m)"
+          description: "Application experiencing elevated error rates"
+```
+

--- a/internal/server/controllers/module.go
+++ b/internal/server/controllers/module.go
@@ -266,6 +266,7 @@ func (c *DefaultModuleController) Subscribe(apis ...*gin.RouterGroup) {
 
 			// Pass-in local-file URI for go-getter
 			uri := fmt.Sprintf("file://%v", onDiskFile.Path())
+
 			if err := c.ModuleService.Upload(&dto, uri, nil); err != nil {
 				ctx.JSON(http.StatusConflict, gin.H{
 					"errors": []string{err.Error()},

--- a/internal/server/controllers/provider.go
+++ b/internal/server/controllers/provider.go
@@ -107,7 +107,6 @@ func (c *DefaultProviderController) Subscribe(apis ...*gin.RouterGroup) {
 				})
 				return
 			}
-
 			ctx.JSON(http.StatusOK, dto)
 		},
 	)
@@ -178,7 +177,7 @@ func (c *DefaultProviderController) Subscribe(apis ...*gin.RouterGroup) {
 			}
 
 			if err := c.ProviderService.Delete(authorityID, name); err != nil {
-				ctx.JSON(http.StatusBadRequest, gin.H{
+				ctx.JSON(http.StatusNotFound, gin.H{
 					"errors": []string{err.Error()},
 				})
 				return

--- a/internal/server/handlers/metrics.go
+++ b/internal/server/handlers/metrics.go
@@ -44,6 +44,11 @@ func PrometheusMetrics(registry *prometheus.Registry) gin.HandlerFunc {
 		duration := time.Since(start).Seconds()
 		status := strconv.Itoa(c.Writer.Status())
 
+		// Record error metrics for 5xx responses
+		if c.Writer.Status() >= 500 {
+			metrics.RecordError("http", "server_error")
+		}
+
 		// Record metrics
 		metrics.HTTPRequestsTotal.WithLabelValues(method, path, status).Inc()
 		metrics.HTTPRequestDuration.WithLabelValues(method, path).Observe(duration)

--- a/internal/server/services/api_key_test.go
+++ b/internal/server/services/api_key_test.go
@@ -115,6 +115,9 @@ func TestGrant(t *testing.T) {
 					mockApiKeyRepository.
 						On("Create", &authority.ApiKey{AuthorityID: authorityID, Name: name}).
 						Return(&authority.ApiKey{Entity: entity.Entity{ID: apiKeyID}}, nil)
+					mockAuthorityService.
+						On("GetByID", authorityID).
+						Return(&authority.Authority{Entity: entity.Entity{ID: authorityID}, ApiKeys: []authority.ApiKey{}}, nil)
 
 					apiKey, err := apiKeyService.Grant(authorityID, name, expireIn)
 
@@ -140,6 +143,9 @@ func TestGrant(t *testing.T) {
 							mockApiKeyRepository.
 								On("Create", mock.AnythingOfType("*authority.ApiKey")).
 								Return(&authority.ApiKey{Entity: entity.Entity{ID: apiKeyID}}, nil)
+							mockAuthorityService.
+								On("GetByID", authorityID).
+								Return(&authority.Authority{Entity: entity.Entity{ID: authorityID}, ApiKeys: []authority.ApiKey{}}, nil)
 
 							apiKey, err := apiKeyService.Grant(authorityID, "key1", expireIn)
 
@@ -184,8 +190,16 @@ func TestRevoke(t *testing.T) {
 		Convey("Given a valid API key", func() {
 			apiKey, _ := uuid.NewRandom()
 			apiKeyStr := apiKey.String()
+			authorityID, _ := uuid.NewRandom()
 
+			mockApiKeyRepository.On("Find", apiKey).Return(&authority.ApiKey{
+				Entity:      entity.Entity{ID: apiKey},
+				AuthorityID: authorityID,
+			}, nil)
 			mockApiKeyRepository.On("Delete", apiKey).Return(nil)
+			mockAuthorityService.
+				On("GetByID", authorityID).
+				Return(&authority.Authority{Entity: entity.Entity{ID: authorityID}, ApiKeys: []authority.ApiKey{}}, nil)
 
 			Convey("When the service is queried", func() {
 				err := apiKeyService.Revoke(apiKeyStr)

--- a/internal/server/services/module.go
+++ b/internal/server/services/module.go
@@ -9,6 +9,7 @@ import (
 	"terralist/internal/server/repositories"
 	"terralist/pkg/docs"
 	"terralist/pkg/file"
+	"terralist/pkg/metrics"
 	"terralist/pkg/storage"
 	"terralist/pkg/version"
 
@@ -54,6 +55,9 @@ func (s *DefaultModuleService) Get(namespace, name, provider string) (*module.Li
 	if err != nil {
 		return nil, err
 	}
+
+	// Record list operation
+	metrics.RecordRequest(namespace, "list")
 
 	dto := m.ToListResponseDTO()
 	return &dto, nil
@@ -119,8 +123,16 @@ func (s *DefaultModuleService) GetVersionURL(namespace, name, provider, version 
 			return nil, fmt.Errorf("could not resolve location: %v", err)
 		}
 
+		// Record download metrics
+		metrics.RecordRequest(namespace, "download")
+		metrics.RecordArtifactDownload("module", namespace)
+
 		return &url, nil
 	}
+
+	// Record download metrics for proxy mode
+	metrics.RecordRequest(namespace, "download")
+	metrics.RecordArtifactDownload("module", namespace)
 
 	return location, nil
 }
@@ -238,6 +250,11 @@ func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string, header ht
 		return err
 	}
 
+	// Record artifact upload metric
+	metrics.RecordArtifactUpload("module", a.Name)
+	// Record upload request
+	metrics.RecordRequest(a.Name, "upload")
+
 	return nil
 }
 
@@ -260,6 +277,11 @@ func (s *DefaultModuleService) Delete(authorityID uuid.UUID, name string, provid
 
 	if err := s.ModuleRepository.Delete(m); err != nil {
 		return err
+	}
+
+	// Record artifact deletion metrics for all versions
+	for range m.Versions {
+		metrics.RecordArtifactDeletion("module", a.Name)
 	}
 
 	return nil
@@ -286,10 +308,18 @@ func (s *DefaultModuleService) DeleteVersion(authorityID uuid.UUID, name string,
 	}
 
 	if len(m.Versions) == 1 {
-		return s.ModuleRepository.Delete(m)
+		if err := s.ModuleRepository.Delete(m); err != nil {
+			return err
+		}
+		metrics.RecordArtifactDeletion("module", a.Name)
+		return nil
 	}
 
-	return s.ModuleRepository.DeleteVersion(v)
+	if err := s.ModuleRepository.DeleteVersion(v); err != nil {
+		return err
+	}
+	metrics.RecordArtifactDeletion("module", a.Name)
+	return nil
 }
 
 // deleteVersion removes the files for a specific module version.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
     - user-guide/index.md
     - AWS S3 Bucket Configuration: user-guide/aws-s3-bucket-configuration.md
     - RBAC Configuration: user-guide/rbac-configuration.md
+    - Monitoring and Observability: user-guide/monitoring.md
   - Developer Guide: 
     - dev-guide/index.md
     - API Reference: dev-guide/api-reference.md

--- a/pkg/metrics/registry.go
+++ b/pkg/metrics/registry.go
@@ -37,6 +37,17 @@ func NewRegistry(cfg *RegistryConfig) *prometheus.Registry {
 		ApplicationErrors,
 	)
 
+	// Register Terralist-specific metrics
+	reg.MustRegister(
+		ArtifactsUploadedTotal,
+		ArtifactsDownloadedTotal,
+		ArtifactsDeletedTotal,
+		ArtifactsTotal,
+		RequestsByAuthorityTotal,
+		ApiKeysTotal, StorageOperationsTotal,
+		StorageBytesTotal,
+		StorageOperationDuration)
+
 	// Register database metrics if SQL DB is provided
 	if cfg != nil && cfg.SqlDB != nil {
 		dbCollectors := NewDatabaseCollectors(cfg.SqlDB)

--- a/pkg/metrics/storage_metrics.go
+++ b/pkg/metrics/storage_metrics.go
@@ -1,0 +1,50 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// StorageOperationsTotal counts storage operations by backend and status.
+	StorageOperationsTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "terralist_storage_operations_total",
+			Help: "Total number of storage operations",
+		},
+		[]string{"operation", "backend", "status"},
+	)
+
+	// StorageBytesTotal tracks total bytes transferred in storage operations.
+	StorageBytesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "terralist_storage_bytes_total",
+			Help: "Total bytes transferred in storage operations",
+		},
+		[]string{"operation", "backend"},
+	)
+
+	// StorageOperationDuration tracks the duration of storage operations.
+	StorageOperationDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "terralist_storage_operation_duration_seconds",
+			Help:    "Duration of storage operations in seconds",
+			Buckets: []float64{0.01, 0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0},
+		},
+		[]string{"operation", "backend"},
+	)
+)
+
+// RecordStorageOperation records a completed storage operation with its metrics.
+// operation: "upload", "download", "delete"
+// backend: "s3", "azure", "gcs", "local"
+// status: "success", "error"
+// durationSeconds: time taken for the operation
+// bytes: number of bytes transferred (use 0 if not applicable)
+func RecordStorageOperation(operation, backend, status string, durationSeconds float64, bytes int64) {
+	StorageOperationsTotal.WithLabelValues(operation, backend, status).Inc()
+	StorageOperationDuration.WithLabelValues(operation, backend).Observe(durationSeconds)
+
+	if bytes > 0 {
+		StorageBytesTotal.WithLabelValues(operation, backend).Add(float64(bytes))
+	}
+}

--- a/pkg/metrics/storage_metrics_test.go
+++ b/pkg/metrics/storage_metrics_test.go
@@ -1,0 +1,127 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordStorageOperation(t *testing.T) {
+	// Reset metrics
+	StorageOperationsTotal.Reset()
+	StorageBytesTotal.Reset()
+	StorageOperationDuration.Reset()
+
+	// Record successful upload
+	RecordStorageOperation("upload", "s3", "success", 1.5, 1024)
+
+	// Verify counter
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("upload", "s3", "success")); count != 1 {
+		t.Errorf("Expected 1 operation, got %f", count)
+	}
+
+	// Verify bytes
+	if bytes := testutil.ToFloat64(StorageBytesTotal.WithLabelValues("upload", "s3")); bytes != 1024 {
+		t.Errorf("Expected 1024 bytes, got %f", bytes)
+	}
+
+	// Note: Histogram verification is done implicitly - if RecordStorageOperation didn't panic, it worked
+}
+
+func TestStorageOperationError(t *testing.T) {
+	StorageOperationsTotal.Reset()
+
+	// Record failed upload
+	RecordStorageOperation("upload", "azure", "error", 0.5, 0)
+
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("upload", "azure", "error")); count != 1 {
+		t.Errorf("Expected 1 error, got %f", count)
+	}
+}
+
+func TestStorageOperationMultipleBackends(t *testing.T) {
+	StorageOperationsTotal.Reset()
+	StorageBytesTotal.Reset()
+
+	// Record operations for different backends
+	RecordStorageOperation("upload", "s3", "success", 1.0, 100)
+	RecordStorageOperation("upload", "gcs", "success", 1.2, 200)
+	RecordStorageOperation("upload", "azure", "success", 0.8, 150)
+
+	// Verify separation by backend
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("upload", "s3", "success")); count != 1 {
+		t.Errorf("Expected 1 s3 upload, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("upload", "gcs", "success")); count != 1 {
+		t.Errorf("Expected 1 gcs upload, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("upload", "azure", "success")); count != 1 {
+		t.Errorf("Expected 1 azure upload, got %f", count)
+	}
+
+	// Verify bytes for each backend
+	if bytes := testutil.ToFloat64(StorageBytesTotal.WithLabelValues("upload", "s3")); bytes != 100 {
+		t.Errorf("Expected 100 bytes for s3, got %f", bytes)
+	}
+
+	if bytes := testutil.ToFloat64(StorageBytesTotal.WithLabelValues("upload", "gcs")); bytes != 200 {
+		t.Errorf("Expected 200 bytes for gcs, got %f", bytes)
+	}
+}
+
+func TestStorageOperationTypes(t *testing.T) {
+	StorageOperationsTotal.Reset()
+
+	// Test different operation types
+	RecordStorageOperation("upload", "s3", "success", 1.0, 500)
+	RecordStorageOperation("download", "s3", "success", 0.5, 0)
+	RecordStorageOperation("delete", "s3", "success", 0.1, 0)
+
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("upload", "s3", "success")); count != 1 {
+		t.Errorf("Expected 1 upload, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("download", "s3", "success")); count != 1 {
+		t.Errorf("Expected 1 download, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(StorageOperationsTotal.WithLabelValues("delete", "s3", "success")); count != 1 {
+		t.Errorf("Expected 1 delete, got %f", count)
+	}
+}
+
+func TestStorageOperationZeroBytes(t *testing.T) {
+	StorageBytesTotal.Reset()
+
+	// Record operation with zero bytes (should not increment bytes counter)
+	RecordStorageOperation("download", "s3", "success", 0.5, 0)
+
+	// Bytes counter should not be created for zero bytes
+	if bytes := testutil.ToFloat64(StorageBytesTotal.WithLabelValues("download", "s3")); bytes != 0 {
+		t.Errorf("Expected 0 bytes for download, got %f", bytes)
+	}
+}
+
+func TestStorageMetricsRegistration(t *testing.T) {
+	// Create a new registry
+	reg := prometheus.NewRegistry()
+
+	// Register metrics
+	err := reg.Register(StorageOperationsTotal)
+	if err != nil {
+		t.Errorf("Failed to register StorageOperationsTotal: %v", err)
+	}
+
+	err = reg.Register(StorageBytesTotal)
+	if err != nil {
+		t.Errorf("Failed to register StorageBytesTotal: %v", err)
+	}
+
+	err = reg.Register(StorageOperationDuration)
+	if err != nil {
+		t.Errorf("Failed to register StorageOperationDuration: %v", err)
+	}
+}

--- a/pkg/metrics/terralist_metrics.go
+++ b/pkg/metrics/terralist_metrics.go
@@ -1,0 +1,88 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	// ArtifactsUploadedTotal counts the total number of uploaded artifacts.
+	ArtifactsUploadedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "terralist_artifacts_uploaded_total",
+			Help: "Total number of artifacts uploaded",
+		},
+		[]string{"type", "authority"},
+	)
+
+	// ArtifactsDownloadedTotal counts the total number of downloaded artifacts.
+	ArtifactsDownloadedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "terralist_artifacts_downloaded_total",
+			Help: "Total number of artifacts downloaded",
+		},
+		[]string{"type", "authority"},
+	)
+
+	// ArtifactsDeletedTotal counts the total number of deleted artifacts.
+	ArtifactsDeletedTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "terralist_artifacts_deleted_total",
+			Help: "Total number of artifacts deleted",
+		},
+		[]string{"type", "authority"},
+	)
+
+	// ArtifactsTotal tracks the current number of artifacts.
+	ArtifactsTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "terralist_artifacts_total",
+			Help: "Current total number of artifacts",
+		},
+		[]string{"type", "authority"},
+	)
+
+	// RequestsByAuthorityTotal counts requests by authority and operation.
+	RequestsByAuthorityTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "terralist_requests_by_authority_total",
+			Help: "Total number of requests by authority and operation type",
+		},
+		[]string{"authority", "operation"},
+	)
+
+	// ApiKeysTotal tracks the number of API keys by authority and status.
+	ApiKeysTotal = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "terralist_api_keys_total",
+			Help: "Current number of API keys by authority and status",
+		},
+		[]string{"authority", "status"},
+	)
+)
+
+// RecordArtifactUpload records an artifact upload.
+func RecordArtifactUpload(artifactType, authority string) {
+	ArtifactsUploadedTotal.WithLabelValues(artifactType, authority).Inc()
+	ArtifactsTotal.WithLabelValues(artifactType, authority).Inc()
+}
+
+// RecordArtifactDownload records an artifact download.
+func RecordArtifactDownload(artifactType, authority string) {
+	ArtifactsDownloadedTotal.WithLabelValues(artifactType, authority).Inc()
+}
+
+// RecordArtifactDeletion records an artifact deletion.
+func RecordArtifactDeletion(artifactType, authority string) {
+	ArtifactsDeletedTotal.WithLabelValues(artifactType, authority).Inc()
+	ArtifactsTotal.WithLabelValues(artifactType, authority).Dec()
+}
+
+// RecordRequest records a request by authority and operation.
+func RecordRequest(authority, operation string) {
+	RequestsByAuthorityTotal.WithLabelValues(authority, operation).Inc()
+}
+
+// SetApiKeysCount sets the number of API keys for an authority with a specific status.
+func SetApiKeysCount(authority, status string, count float64) {
+	ApiKeysTotal.WithLabelValues(authority, status).Set(count)
+}

--- a/pkg/metrics/terralist_metrics_test.go
+++ b/pkg/metrics/terralist_metrics_test.go
@@ -1,0 +1,193 @@
+package metrics
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+func TestRecordArtifactUpload(t *testing.T) {
+	// Reset metrics
+	ArtifactsUploadedTotal.Reset()
+	ArtifactsTotal.Reset()
+
+	// Record upload
+	RecordArtifactUpload("module", "test-authority")
+
+	// Check uploaded counter
+	if count := testutil.ToFloat64(ArtifactsUploadedTotal.WithLabelValues("module", "test-authority")); count != 1 {
+		t.Errorf("Expected ArtifactsUploadedTotal to be 1, got %f", count)
+	}
+
+	// Check total gauge
+	if count := testutil.ToFloat64(ArtifactsTotal.WithLabelValues("module", "test-authority")); count != 1 {
+		t.Errorf("Expected ArtifactsTotal to be 1, got %f", count)
+	}
+
+	// Record another upload
+	RecordArtifactUpload("module", "test-authority")
+
+	if count := testutil.ToFloat64(ArtifactsUploadedTotal.WithLabelValues("module", "test-authority")); count != 2 {
+		t.Errorf("Expected ArtifactsUploadedTotal to be 2, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(ArtifactsTotal.WithLabelValues("module", "test-authority")); count != 2 {
+		t.Errorf("Expected ArtifactsTotal to be 2, got %f", count)
+	}
+}
+
+func TestRecordArtifactDownload(t *testing.T) {
+	// Reset metrics
+	ArtifactsDownloadedTotal.Reset()
+
+	// Record download
+	RecordArtifactDownload("provider", "test-authority")
+
+	if count := testutil.ToFloat64(ArtifactsDownloadedTotal.WithLabelValues("provider", "test-authority")); count != 1 {
+		t.Errorf("Expected ArtifactsDownloadedTotal to be 1, got %f", count)
+	}
+
+	// Record multiple downloads
+	RecordArtifactDownload("provider", "test-authority")
+	RecordArtifactDownload("provider", "test-authority")
+
+	if count := testutil.ToFloat64(ArtifactsDownloadedTotal.WithLabelValues("provider", "test-authority")); count != 3 {
+		t.Errorf("Expected ArtifactsDownloadedTotal to be 3, got %f", count)
+	}
+}
+
+func TestRecordArtifactDeletion(t *testing.T) {
+	// Reset and setup
+	ArtifactsDeletedTotal.Reset()
+	ArtifactsTotal.Reset()
+
+	// Set initial state
+	ArtifactsTotal.WithLabelValues("module", "test-authority").Set(5)
+
+	// Record deletion
+	RecordArtifactDeletion("module", "test-authority")
+
+	// Check deleted counter
+	if count := testutil.ToFloat64(ArtifactsDeletedTotal.WithLabelValues("module", "test-authority")); count != 1 {
+		t.Errorf("Expected ArtifactsDeletedTotal to be 1, got %f", count)
+	}
+
+	// Check total gauge decreased
+	if count := testutil.ToFloat64(ArtifactsTotal.WithLabelValues("module", "test-authority")); count != 4 {
+		t.Errorf("Expected ArtifactsTotal to be 4, got %f", count)
+	}
+}
+
+func TestRecordRequest(t *testing.T) {
+	// Reset metrics
+	RequestsByAuthorityTotal.Reset()
+
+	// Record different operations
+	RecordRequest("authority1", "upload")
+	RecordRequest("authority1", "upload")
+	RecordRequest("authority1", "download")
+	RecordRequest("authority2", "list")
+
+	// Check counts
+	if count := testutil.ToFloat64(RequestsByAuthorityTotal.WithLabelValues("authority1", "upload")); count != 2 {
+		t.Errorf("Expected authority1/upload to be 2, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(RequestsByAuthorityTotal.WithLabelValues("authority1", "download")); count != 1 {
+		t.Errorf("Expected authority1/download to be 1, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(RequestsByAuthorityTotal.WithLabelValues("authority2", "list")); count != 1 {
+		t.Errorf("Expected authority2/list to be 1, got %f", count)
+	}
+}
+
+func TestSetApiKeysCount(t *testing.T) {
+	// Reset metrics
+	ApiKeysTotal.Reset()
+
+	// Set counts
+	SetApiKeysCount("test-authority", "active", 5)
+	SetApiKeysCount("test-authority", "expired", 2)
+
+	// Check values
+	if count := testutil.ToFloat64(ApiKeysTotal.WithLabelValues("test-authority", "active")); count != 5 {
+		t.Errorf("Expected active keys to be 5, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(ApiKeysTotal.WithLabelValues("test-authority", "expired")); count != 2 {
+		t.Errorf("Expected expired keys to be 2, got %f", count)
+	}
+
+	// Update counts
+	SetApiKeysCount("test-authority", "active", 6)
+
+	if count := testutil.ToFloat64(ApiKeysTotal.WithLabelValues("test-authority", "active")); count != 6 {
+		t.Errorf("Expected active keys to be 6, got %f", count)
+	}
+}
+
+func TestMultipleAuthoritiesMetrics(t *testing.T) {
+	// Reset all metrics
+	ArtifactsUploadedTotal.Reset()
+	ArtifactsTotal.Reset()
+	RequestsByAuthorityTotal.Reset()
+
+	// Record for multiple authorities
+	RecordArtifactUpload("module", "authority-a")
+	RecordArtifactUpload("module", "authority-b")
+	RecordArtifactUpload("provider", "authority-a")
+
+	RecordRequest("authority-a", "upload")
+	RecordRequest("authority-b", "upload")
+
+	// Verify separation
+	if count := testutil.ToFloat64(ArtifactsUploadedTotal.WithLabelValues("module", "authority-a")); count != 1 {
+		t.Errorf("Expected authority-a module uploads to be 1, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(ArtifactsUploadedTotal.WithLabelValues("module", "authority-b")); count != 1 {
+		t.Errorf("Expected authority-b module uploads to be 1, got %f", count)
+	}
+
+	if count := testutil.ToFloat64(ArtifactsUploadedTotal.WithLabelValues("provider", "authority-a")); count != 1 {
+		t.Errorf("Expected authority-a provider uploads to be 1, got %f", count)
+	}
+}
+
+func TestMetricsRegistration(t *testing.T) {
+	// Create a new registry
+	reg := prometheus.NewRegistry()
+
+	// Register metrics
+	err := reg.Register(ArtifactsUploadedTotal)
+	if err != nil {
+		t.Errorf("Failed to register ArtifactsUploadedTotal: %v", err)
+	}
+
+	err = reg.Register(ArtifactsDownloadedTotal)
+	if err != nil {
+		t.Errorf("Failed to register ArtifactsDownloadedTotal: %v", err)
+	}
+
+	err = reg.Register(ArtifactsDeletedTotal)
+	if err != nil {
+		t.Errorf("Failed to register ArtifactsDeletedTotal: %v", err)
+	}
+
+	err = reg.Register(ArtifactsTotal)
+	if err != nil {
+		t.Errorf("Failed to register ArtifactsTotal: %v", err)
+	}
+
+	err = reg.Register(RequestsByAuthorityTotal)
+	if err != nil {
+		t.Errorf("Failed to register RequestsByAuthorityTotal: %v", err)
+	}
+
+	err = reg.Register(ApiKeysTotal)
+	if err != nil {
+		t.Errorf("Failed to register ApiKeysTotal: %v", err)
+	}
+}

--- a/pkg/storage/metrics_resolver.go
+++ b/pkg/storage/metrics_resolver.go
@@ -1,0 +1,69 @@
+package storage
+
+import (
+	"time"
+
+	"terralist/pkg/metrics"
+)
+
+// MetricsResolver wraps a Resolver and records metrics for all operations.
+// It implements the Decorator pattern to add observability without modifying
+// the underlying resolver implementations.
+type MetricsResolver struct {
+	Resolver Resolver
+	Backend  string
+}
+
+// Store uploads a file and records metrics.
+func (m *MetricsResolver) Store(in *StoreInput) (string, error) {
+	start := time.Now()
+
+	key, err := m.Resolver.Store(in)
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+		metrics.RecordError("storage", "error")
+	}
+
+	metrics.RecordStorageOperation("upload", m.Backend, status, duration, in.Size)
+
+	return key, err
+}
+
+// Find retrieves a URL for a stored file and records metrics.
+func (m *MetricsResolver) Find(key string) (string, error) {
+	start := time.Now()
+
+	url, err := m.Resolver.Find(key)
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+		metrics.RecordError("storage", "error")
+	}
+
+	metrics.RecordStorageOperation("download", m.Backend, status, duration, 0)
+
+	return url, err
+}
+
+// Purge removes a stored file and records metrics.
+func (m *MetricsResolver) Purge(key string) error {
+	start := time.Now()
+
+	err := m.Resolver.Purge(key)
+
+	duration := time.Since(start).Seconds()
+	status := "success"
+	if err != nil {
+		status = "error"
+		metrics.RecordError("storage", "error")
+	}
+
+	metrics.RecordStorageOperation("delete", m.Backend, status, duration, 0)
+
+	return err
+}


### PR DESCRIPTION
- Add Terralist-specific metrics for artifacts and requests
  - Track artifact uploads, downloads, deletions, and counts by type/authority
  - Monitor requests by authority and operation type
  - Track API keys by authority and status (active/expired)

- Add storage backend metrics
  - Monitor storage operations (upload/download/delete) by backend and status
  - Track bytes transferred and operation durations
  - Support for S3, Azure, GCS, and local storage backends

- Implement MetricsResolver decorator pattern
  - Wrap storage resolvers to record metrics without code changes
  - Automatic error tracking for storage operations

- Integrate metrics into services
  - Module and provider services now record upload/download/delete metrics
  - API key service tracks key creation and revocation
  - HTTP middleware records 5xx errors

- Add monitoring documentation
  - Comprehensive guide with metric descriptions
  - Example Prometheus queries and alerting rules
  - Configuration examples for monitoring setup

- Fix minor issues
  - Correct HTTP status code in provider controller (404 vs 400)
  - Remove extraneous blank line in provider controller
  - Add blank line in module controller for consistency