### PR TITLE
feat: documentation nullable now in DB

### DIFF
--- a/internal/server/migration.go
+++ b/internal/server/migration.go
@@ -29,5 +29,10 @@ func (*InitialMigration) Migrate(db *database.DB) error {
 		return err
 	}
 
+	// Remove default empty string column in Version.Documentation
+	if err := db.Migrator().AlterColumn(&module.Version{}, "Documentation"); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/internal/server/migration_test.go
+++ b/internal/server/migration_test.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"database/sql"
+	"testing"
+	"time"
+
+	"github.com/glebarez/sqlite"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type legacyModuleVersion struct {
+	ID            uuid.UUID `gorm:"primary_key;"`
+	CreatedAt     time.Time
+	UpdatedAt     time.Time
+	ModuleID      uuid.UUID
+	Version       string `gorm:"not null"`
+	Location      string `gorm:"not null"`
+	Documentation string `gorm:"not null;default:''"`
+}
+
+func (legacyModuleVersion) TableName() string {
+	return "module_versions"
+}
+
+type tableInfo struct {
+	Name      string         `gorm:"column:name"`
+	DfltValue sql.NullString `gorm:"column:dflt_value"`
+}
+
+func TestInitialMigrationDropsModuleDocumentationDefault(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open sqlite database: %v", err)
+	}
+
+	if err := db.AutoMigrate(&legacyModuleVersion{}); err != nil {
+		t.Fatalf("failed to create legacy schema: %v", err)
+	}
+
+	before, err := documentationColumnDefault(db)
+	if err != nil {
+		t.Fatalf("failed to inspect legacy schema: %v", err)
+	}
+	if !before.Valid {
+		t.Fatal("expected legacy schema to have a default for module_versions.documentation")
+	}
+
+	if err := (&InitialMigration{}).Migrate(db); err != nil {
+		t.Fatalf("failed to run initial migration: %v", err)
+	}
+
+	after, err := documentationColumnDefault(db)
+	if err != nil {
+		t.Fatalf("failed to inspect migrated schema: %v", err)
+	}
+	if after.Valid {
+		t.Fatalf("expected module_versions.documentation default to be removed, got %q", after.String)
+	}
+}
+
+func documentationColumnDefault(db *gorm.DB) (sql.NullString, error) {
+	var columns []tableInfo
+	if err := db.Raw("PRAGMA table_info('module_versions')").Scan(&columns).Error; err != nil {
+		return sql.NullString{}, err
+	}
+
+	for _, column := range columns {
+		if column.Name == "documentation" {
+			return column.DfltValue, nil
+		}
+	}
+
+	return sql.NullString{}, gorm.ErrRecordNotFound
+}

--- a/internal/server/models/module/version.go
+++ b/internal/server/models/module/version.go
@@ -11,9 +11,9 @@ type Version struct {
 	entity.Entity
 	ModuleID      uuid.UUID
 	Module        Module
-	Version       string       `gorm:"not null"`
-	Location      string       `gorm:"not null"`
-	Documentation string       `gorm:"not null;default:''"` // TODO: This adds backwards-compatibility, we should remove it in future versions
+	Version       string `gorm:"not null"`
+	Location      string `gorm:"not null"`
+	Documentation *string
 	Providers     []Provider   `gorm:"foreignKey:ParentID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	Dependencies  []Dependency `gorm:"foreignKey:ParentID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
 	Submodules    []Submodule  `gorm:"foreignKey:VersionID;constraint:OnUpdate:CASCADE,OnDelete:CASCADE"`
@@ -29,9 +29,15 @@ func (v Version) ToDTO() VersionDTO {
 		submodulesDTO = append(submodulesDTO, sm.ToDTO())
 	}
 
+	var doc *string
+	if v.Documentation != nil && *v.Documentation != "" {
+		s := *v.Documentation
+		doc = &s
+	}
+
 	return VersionDTO{
 		Version:       v.Version,
-		Documentation: v.Documentation,
+		Documentation: doc,
 		Submodules:    submodulesDTO,
 	}
 }
@@ -43,14 +49,18 @@ type RootDTO struct {
 
 type VersionDTO struct {
 	Version       string                 `json:"version"`
-	Documentation string                 `json:"documentation"`
+	Documentation *string                `json:"documentation,omitempty"`
 	Submodules    []SubmoduleResponseDTO `json:"submodules,omitempty"`
 }
 
 func (v VersionDTO) ToArtifactVersion() artifact.Version {
+	doc := ""
+	if v.Documentation != nil {
+		doc = *v.Documentation
+	}
 	return artifact.Version{
 		Tag:           v.Version,
-		Documentation: v.Documentation,
+		Documentation: doc,
 	}
 }
 

--- a/internal/server/services/module.go
+++ b/internal/server/services/module.go
@@ -77,8 +77,8 @@ func (s *DefaultModuleService) GetVersion(namespace, name, provider, version str
 
 	dto := &module.VersionDTO{Version: v.Version}
 
-	if s.Resolver != nil {
-		url, err := s.Resolver.Find(v.Documentation)
+	if s.Resolver != nil && v.Documentation != nil && *v.Documentation != "" {
+		url, err := s.Resolver.Find(*v.Documentation)
 		if err != nil {
 			log.Warn().
 				Str("moduleSlug", fmt.Sprintf("%s/%s/%s/%s", namespace, name, provider, version)).
@@ -111,7 +111,10 @@ func (s *DefaultModuleService) GetVersion(namespace, name, provider, version str
 			return dto, nil
 		}
 
-		dto.Documentation = string(body)
+		bodyStr := string(body)
+		if bodyStr != "" {
+			dto.Documentation = &bodyStr
+		}
 	}
 
 	return dto, nil
@@ -408,7 +411,7 @@ func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string, header ht
 		}
 
 		// Update the module documentation location
-		m.Versions[0].Documentation = docsLocation
+		m.Versions[0].Documentation = &docsLocation
 
 		// Upload submodule documentation to the resolver datastore
 		for submodulePath, submoduleDoc := range submoduleDocs {
@@ -558,13 +561,13 @@ func (s *DefaultModuleService) deleteVersion(namespace string, v *module.Version
 	}
 
 	// Delete the module documentation
-	if v.Documentation != "" {
-		if err := s.Resolver.Purge(v.Documentation); err != nil {
+	if v.Documentation != nil && *v.Documentation != "" {
+		if err := s.Resolver.Purge(*v.Documentation); err != nil {
 			log.Warn().
 				AnErr("Error", err).
 				Str("Module", v.Module.String()).
 				Str("Version", v.Version).
-				Str("Key", v.Documentation).
+				Str("Key", *v.Documentation).
 				Msg("Could not purge module documentation, require manual clean-up")
 		}
 	}

--- a/web/src/api/artifacts.ts
+++ b/web/src/api/artifacts.ts
@@ -15,7 +15,7 @@ type Submodule = {
 
 type ArtifactVersionWithDocumentation = {
   version: ArtifactVersion;
-  documentation: string;
+  documentation?: string;
   submodules?: Submodule[];
 };
 


### PR DESCRIPTION
No longer insert empty string into DB for missing or empty documentation. Make column nullable as the UI can handle if the Documentation field is missing from the DTO.