### PR TITLE
fix: submodule picker not showing and documentation not loading

### DIFF
--- a/internal/server/services/module.go
+++ b/internal/server/services/module.go
@@ -75,7 +75,8 @@ func (s *DefaultModuleService) GetVersion(namespace, name, provider, version str
 		return nil, err
 	}
 
-	dto := &module.VersionDTO{Version: v.Version}
+	result := v.ToDTO()
+	dto := &result
 
 	if s.Resolver != nil && v.Documentation != nil && *v.Documentation != "" {
 		url, err := s.Resolver.Find(*v.Documentation)

--- a/web/src/api/artifacts.ts
+++ b/web/src/api/artifacts.ts
@@ -175,7 +175,7 @@ const actions = {
   ) =>
     client
       .get<{ documentation: string }>(
-        `/modules/${name}/${provider}/${version}/submodules/${submodulePath}`,
+        `/modules/${namespace}/${name}/${provider}/${version}/submodules/${submodulePath}`,
         {
           baseURL: '/v1/api'
         }


### PR DESCRIPTION
This PR fixes two bugs that prevented submodule documentation from displaying in the web UI:

- Use `Version.ToDTO()` in `GetVersion` to include the submodules list in the API response. Previously, the DTO was manually constructed with only the version field, so the submodules array was always empty and the picker never appeared.
- Add the missing `namespace` parameter to the submodule documentation fetch URL in the frontend. The URL was not updated when endpoints migrated to namespaced paths, causing 404 errors.