### PR TITLE
feat: Support _FILE env vars for App Secrets

### DIFF
--- a/cmd/terralist/main.go
+++ b/cmd/terralist/main.go
@@ -23,6 +23,7 @@ var (
 func main() {
 	if err := cli.LoadEnvFiles(
 		"TERRALIST_TOKEN_SIGNING_SECRET",
+		"TERRALIST_COOKIE_SECRET",
 		"TERRALIST_GH_CLIENT_ID",
 		"TERRALIST_GH_CLIENT_SECRET",
 		"TERRALIST_BB_CLIENT_ID",
@@ -31,8 +32,10 @@ func main() {
 		"TERRALIST_GL_CLIENT_SECRET",
 		"TERRALIST_OI_CLIENT_ID",
 		"TERRALIST_OI_CLIENT_SECRET",
+		"TERRALIST_MYSQL_URL",
+		"TERRALIST_MYSQL_PASSWORD",
 		"TERRALIST_POSTGRES_URL",
-		"TERRALIST_COOKIE_SECRET",
+		"TERRALIST_POSTGRES_PASSWORD",
 	); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "load env files: %v\n", err)
 		os.Exit(1)

--- a/cmd/terralist/main.go
+++ b/cmd/terralist/main.go
@@ -1,10 +1,12 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"terralist/cmd/terralist/server"
 	"terralist/cmd/terralist/version"
+	"terralist/pkg/cli"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -19,6 +21,20 @@ var (
 )
 
 func main() {
+	if err := cli.LoadEnvFiles(
+		"TERRALIST_GH_CLIENT_ID",
+		"TERRALIST_GH_CLIENT_SECRET",
+		"TERRALIST_BB_CLIENT_ID",
+		"TERRALIST_BB_CLIENT_SECRET",
+		"TERRALIST_GL_CLIENT_ID",
+		"TERRALIST_GL_CLIENT_SECRET",
+		"TERRALIST_OI_CLIENT_ID",
+		"TERRALIST_OI_CLIENT_SECRET",
+	); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "load env files: %v\n", err)
+		os.Exit(1)
+	}
+
 	// rootCmd is the base command onto which other commands are added
 	rootCmd := &cobra.Command{
 		Use:   "terralist",

--- a/cmd/terralist/main.go
+++ b/cmd/terralist/main.go
@@ -22,6 +22,7 @@ var (
 
 func main() {
 	if err := cli.LoadEnvFiles(
+		"TERRALIST_TOKEN_SIGNING_SECRET",
 		"TERRALIST_GH_CLIENT_ID",
 		"TERRALIST_GH_CLIENT_SECRET",
 		"TERRALIST_BB_CLIENT_ID",
@@ -30,6 +31,8 @@ func main() {
 		"TERRALIST_GL_CLIENT_SECRET",
 		"TERRALIST_OI_CLIENT_ID",
 		"TERRALIST_OI_CLIENT_SECRET",
+		"TERRALIST_POSTGRES_URL",
+		"TERRALIST_COOKIE_SECRET",
 	); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "load env files: %v\n", err)
 		os.Exit(1)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -191,6 +191,8 @@ Preferred email domain for authentication. When set, providers that return multi
 ### `gh-client-id`
 
 The GitHub OAuth Application client ID.
+When using environment variables, `TERRALIST_GH_CLIENT_ID` is the first-class env var.
+You can also set `TERRALIST_GH_CLIENT_ID_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_GH_CLIENT_ID`.
 
 | Name | Value |
 | --- | --- |
@@ -203,6 +205,8 @@ The GitHub OAuth Application client ID.
 ### `gh-client-secret`
 
 The GitHub OAuth Application client secret.
+When using environment variables, `TERRALIST_GH_CLIENT_SECRET` is the first-class env var.
+You can also set `TERRALIST_GH_CLIENT_SECRET_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_GH_CLIENT_SECRET`.
 
 | Name | Value |
 | --- | --- |
@@ -251,6 +255,8 @@ The GitHub base domain if you are using GitHub Enterprise.
 ### `bb-client-id`
 
 The BitBucket OAuth Application client ID.
+When using environment variables, `TERRALIST_BB_CLIENT_ID` is the first-class env var.
+You can also set `TERRALIST_BB_CLIENT_ID_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_BB_CLIENT_ID`.
 
 | Name | Value |
 | --- | --- |
@@ -263,6 +269,8 @@ The BitBucket OAuth Application client ID.
 ### `bb-client-secret`
 
 The BitBucket OAuth Application client secret.
+When using environment variables, `TERRALIST_BB_CLIENT_SECRET` is the first-class env var.
+You can also set `TERRALIST_BB_CLIENT_SECRET_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_BB_CLIENT_SECRET`.
 
 | Name | Value |
 | --- | --- |
@@ -287,6 +295,8 @@ The BitBucket workspace to use for user validation.
 ### `gl-client-id`
 
 The GitLab OAuth Application client ID.
+When using environment variables, `TERRALIST_GL_CLIENT_ID` is the first-class env var.
+You can also set `TERRALIST_GL_CLIENT_ID_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_GL_CLIENT_ID`.
 
 | Name | Value |
 | --- | --- |
@@ -299,6 +309,8 @@ The GitLab OAuth Application client ID.
 ### `gl-client-secret`
 
 The Gitlab OAuth Application client secret.
+When using environment variables, `TERRALIST_GL_CLIENT_SECRET` is the first-class env var.
+You can also set `TERRALIST_GL_CLIENT_SECRET_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_GL_CLIENT_SECRET`.
 
 | Name | Value |
 | --- | --- |
@@ -335,6 +347,8 @@ The GitLab groups names the user must be member of. It must be comma separated w
 ### `oi-client-id`
 
 The OpenID Connect client ID.
+When using environment variables, `TERRALIST_OI_CLIENT_ID` is the first-class env var.
+You can also set `TERRALIST_OI_CLIENT_ID_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_OI_CLIENT_ID`.
 
 | Name | Value |
 | --- | --- |
@@ -347,6 +361,8 @@ The OpenID Connect client ID.
 ### `oi-client-secret`
 
 The OpenID Connect client secret.
+When using environment variables, `TERRALIST_OI_CLIENT_SECRET` is the first-class env var.
+You can also set `TERRALIST_OI_CLIENT_SECRET_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_OI_CLIENT_SECRET`.
 
 | Name | Value |
 | --- | --- |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -105,6 +105,8 @@ Serve Prometheus metrics on a separate port. When set, `/metrics` is not exposed
 ### `token-signing-secret`
 
 The secret to use when signing authorization tokens.
+When using environment variables, `TERRALIST_TOKEN_SIGNING_SECRET` is the first-class env var.
+You can also set `TERRALIST_TOKEN_SIGNING_SECRET_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_TOKEN_SIGNING_SECRET`.
 
 | Name | Value |
 | --- | --- |
@@ -556,6 +558,8 @@ The database backend.
 ### `postgres-url`
 
 The URL that can be used to connect to PostgreSQL database.
+When using environment variables, `TERRALIST_POSTGRES_URL` is the first-class env var.
+You can also set `TERRALIST_POSTGRES_URL_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_POSTGRES_URL`.
 
 | Name | Value |
 | --- | --- |
@@ -727,6 +731,8 @@ The session store backend. The `cookie` backend stores all session data in the b
 ### `cookie-secret`
 
 The secret used for cookie signing. When using the `cookie` session store, this also encrypts the session data. When using the `database` session store, this signs the session ID cookie.
+When using environment variables, `TERRALIST_COOKIE_SECRET` is the first-class env var.
+You can also set `TERRALIST_COOKIE_SECRET_FILE` to a file path, and Terralist will read that file at startup and assign its contents to `TERRALIST_COOKIE_SECRET`.
 
 | Name | Value |
 | --- | --- |

--- a/pkg/cli/env_file.go
+++ b/pkg/cli/env_file.go
@@ -1,0 +1,33 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+)
+
+// LoadEnvFiles copies the contents of <ENV>_FILE into <ENV>.
+func LoadEnvFiles(envNames ...string) error {
+	for _, envName := range envNames {
+		fileEnvName := envName + "_FILE"
+
+		filePath, ok := os.LookupEnv(fileEnvName)
+		if !ok {
+			continue
+		}
+
+		if _, ok := os.LookupEnv(envName); ok {
+			return fmt.Errorf("%s and %s cannot both be set", envName, fileEnvName)
+		}
+
+		value, err := os.ReadFile(filePath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", fileEnvName, err)
+		}
+
+		if err := os.Setenv(envName, string(value)); err != nil {
+			return fmt.Errorf("set %s from %s: %w", envName, fileEnvName, err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cli/env_file_test.go
+++ b/pkg/cli/env_file_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadEnvFilesSetsValueFromFile(t *testing.T) {
+	t.Setenv("TERRALIST_OI_CLIENT_ID", "")
+	t.Setenv("TERRALIST_OI_CLIENT_ID_FILE", "")
+
+	secretPath := filepath.Join(t.TempDir(), "client-id")
+	if err := os.WriteFile(secretPath, []byte("client-id-from-file"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+
+	if err := os.Setenv("TERRALIST_OI_CLIENT_ID_FILE", secretPath); err != nil {
+		t.Fatalf("set _FILE env: %v", err)
+	}
+
+	if err := os.Unsetenv("TERRALIST_OI_CLIENT_ID"); err != nil {
+		t.Fatalf("unset target env: %v", err)
+	}
+
+	if err := LoadEnvFiles("TERRALIST_OI_CLIENT_ID"); err != nil {
+		t.Fatalf("LoadEnvFiles() error = %v", err)
+	}
+
+	if got := os.Getenv("TERRALIST_OI_CLIENT_ID"); got != "client-id-from-file" {
+		t.Fatalf("TERRALIST_OI_CLIENT_ID = %q, want %q", got, "client-id-from-file")
+	}
+}
+
+func TestLoadEnvFilesErrorsWhenBothEnvAndFileAreSet(t *testing.T) {
+	t.Setenv("TERRALIST_OI_CLIENT_SECRET", "inline-secret")
+
+	secretPath := filepath.Join(t.TempDir(), "client-secret")
+	if err := os.WriteFile(secretPath, []byte("secret-from-file"), 0o600); err != nil {
+		t.Fatalf("write secret file: %v", err)
+	}
+
+	t.Setenv("TERRALIST_OI_CLIENT_SECRET_FILE", secretPath)
+
+	err := LoadEnvFiles("TERRALIST_OI_CLIENT_SECRET")
+	if err == nil {
+		t.Fatal("LoadEnvFiles() error = nil, want conflict error")
+	}
+
+	if !strings.Contains(err.Error(), "cannot both be set") {
+		t.Fatalf("LoadEnvFiles() error = %q, want conflict message", err)
+	}
+}


### PR DESCRIPTION
Adds support for parsing `*_CLIENT_ID_FILE` and `*_CLIENT_SECRET_FILE` environment variables to load the contents of a file path into the corresponding `*_CLIENT_ID` and `*_CLIENT_SECRET` environment variables. This makes it easier to support file-based secrets in hosting environments such as AWS EKS, and GKE and native Kubernetes.

Also adds `TERRALIST_TOKEN_SIGNING_SECRET` , `TERRALIST_COOKIE_SECRET`, `TERRALIST_POSTGRES_URL`, `TERRALIST_POSTGRES_PASSWORD`,  `TERRALIST_MYSQL_URL`, and `TERRALIST_MYSQL_PASSWORD`  *_FILE variants