### PR TITLE
fix: extend `local.Resolver` unwrapping to `NewServer()`

### DIFF
--- a/internal/server/controllers/file.go
+++ b/internal/server/controllers/file.go
@@ -53,8 +53,8 @@ func (c *DefaultFileServer) Paths() []string {
 func (c *DefaultFileServer) Subscribe(apis ...*gin.RouterGroup) {
 	api := apis[0]
 
-	localModulesResolver := unwrapLocalResolver(c.ModulesResolver)
-	localProvidersResolver := unwrapLocalResolver(c.ProvidersResolver)
+	localModulesResolver := local.UnwrapResolver(c.ModulesResolver)
+	localProvidersResolver := local.UnwrapResolver(c.ProvidersResolver)
 
 	api.GET("/*filepath", func(ctx *gin.Context) {
 		fileKey := strings.TrimPrefix(ctx.Param("filepath"), "/")
@@ -113,15 +113,4 @@ func (c *DefaultFileServer) Subscribe(apis ...*gin.RouterGroup) {
 
 		ctx.Status(http.StatusOK)
 	})
-}
-
-func unwrapLocalResolver(resolver storage.Resolver) *local.Resolver {
-	switch r := resolver.(type) {
-	case *local.Resolver:
-		return r
-	case *storage.MetricsResolver:
-		return unwrapLocalResolver(r.Resolver)
-	default:
-		return nil
-	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -433,9 +433,9 @@ func NewServer(userConfig UserConfig, config Config) (*Server, error) {
 
 	apiV1Group.Register(artifactController)
 
-	_, modulesLocal := config.ModulesResolver.(*local.Resolver)
-	_, providersLocal := config.ProvidersResolver.(*local.Resolver)
-	if modulesLocal || providersLocal {
+	modulesLocal := local.UnwrapResolver(config.ModulesResolver)
+	providersLocal := local.UnwrapResolver(config.ProvidersResolver)
+	if modulesLocal != nil || providersLocal != nil {
 		localJWTManager, err := jwt.New(userConfig.LocalTokenSigningSecret)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create local JWT manager: %v", err)

--- a/pkg/storage/local/resolver.go
+++ b/pkg/storage/local/resolver.go
@@ -119,3 +119,14 @@ func (r *Resolver) Purge(key string) error {
 
 	return os.Remove(filePath)
 }
+
+func UnwrapResolver(resolver storage.Resolver) *Resolver {
+	switch r := resolver.(type) {
+	case *Resolver:
+		return r
+	case *storage.MetricsResolver:
+		return UnwrapResolver(r.Resolver)
+	default:
+		return nil
+	}
+}


### PR DESCRIPTION
I've been playing with Terralist for the last two days, trying to set up a new internal private module registry, and I've hit a bit of a wall getting it to save and return new modules when using it as a local private registry.

When I set up the configuration as follows (for local testing):

```yaml
modules-storage-resolver: local
providers-storage-resolver: local
local-store: /home/jonathan/tmp/terralist/store
local-registry: /home/jonathan/tmp/terralist/registry
```

I can successfully call `/v1/.../upload` and `/v1/.../upload-files` via the API, and I can see the `{version}.zip` archive and the associated extracted Markdown files for the module and submodules on the filesystem, alongside the entry in the UI.

However, any attempt to view either the module or any of its submodules in the UI partially fails with a "404 page not found" error under the _Readme_ header. Any attempt to use the module in a `module {}` block resulted in Terraform outputting "bad response code: 404".

Trying direct downloads failed with 404 too. The JWT token provided in the query string was tested and validated correctly. A 404 was showing in the logs. But interestingly, I didn't see a permissions issue when I removed the `?token=` parameter from the query string: It still returned a straight 404 error.

After debugging a bit this evening, I've managed to trace it back to a check in `server.NewServer()` that tests whether the resolvers for the modules and/or providers are of type `*local.Resolver`. It seems that they're normally wrapped by `storage.MetricsResolver` at this stage, so the test fails, and so the routes are never added to the server.

As a result, I've moved the `unwrapLocalResover()` into the `storage.Local` package, exported it, and shared it between `DefaultFileServer.Subscribe()` and `server.NewServer()` to allow `NewServer()` to correctly process `config.ModulesResolver` and `config.ProvidersResolver`. In my local test, I can now access the `README.md` files and the module itself.

Not sure if this 100% the right way to go about it. I'm more of an "ops" guy with some reasonable Go knowledge :smile: but it seems sane, the tests continue to pass, and it's working fine for me now!