### PR TITLE
chore(deps): update alpine libcap to 2.78

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN addgroup terralist && \
 
 RUN apk add --no-cache \
   git~=2.52 \
-  libcap~=2.77 \
+  libcap~=2.78 \
   dumb-init~=1.2 \
   su-exec~=0.3
 


### PR DESCRIPTION
This PR bumps the libcap version pin in the Dockerfile from 2.77 to 2.78 to fix the Docker image build.