### PR TITLE
feat: Finish GitHub markdown support

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -266,6 +266,13 @@ tasks:
         go test -count=1 {{if eq .WITH_COVER "true"}}-coverprofile={{.COVER_PROFILE}}{{end}} {{.TEST_PACKAGES}}
         {{- end -}}
 
+  test:unit:frontend:
+    desc: "Run frontend unit tests."
+    silent: true
+    dir: web
+    cmds:
+      - yarn run test:unit
+
   test:e2e:
     desc: "Run all E2E tests."
     silent: true
@@ -282,6 +289,7 @@ tasks:
       - task: test:unit
         vars:
           WITH_COVER: "true"
+      - task: test:unit:frontend
       - task: test:e2e
 
   test:coverage:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -26,6 +26,12 @@ tasks:
       - go mod tidy
       - cd {{.TOOLS_DIR}} && go mod tidy
 
+  server:clean:
+    desc: "Remove web build output, web/node_modules, and the Go build cache."
+    cmds:
+      - rm -rf web/dist web/node_modules
+      - go clean -cache
+
   build:frontend:
     desc: "Build the web application."
     silent: true
@@ -180,6 +186,20 @@ tasks:
         vars:
           WITH_DEBUG_MODE: "true"
           WITH_COVER: "true"
+      # Stop any lingering e2e containers from a prior run that was killed
+      # before its cleanup could run. Without this, port 9000/8080 may be
+      # held by an orphan and the subsequent `docker run` will fail.
+      - cmd: |
+          ids=$(docker ps -q --filter 'name=^terralist-(rustfs|mock-oauth2)-e2e-')
+          [ -n "$ids" ] && docker stop $ids || true
+        ignore_error: true
+      - defer: rm -f $TERRALIST_SQLITE_PATH
+      - defer:
+          cmd: docker stop terralist-rustfs-e2e-{{.TEST_RUN_ID}} terralist-mock-oauth2-e2e-{{.TEST_RUN_ID}}
+          ignore_error: true
+      - defer:
+          cmd: pkill -f "{{.BINARY_FILE_NAME}} server"
+          ignore_error: true
       - >
         docker run
         --rm
@@ -210,10 +230,6 @@ tasks:
       - ./{{.BINARY_FILE_NAME}} server &
       - cmd: read -p "Press any key to stop..."
         ignore_error: true
-      - cmd: pkill -f "{{.BINARY_FILE_NAME}} server"
-        ignore_error: true
-      - docker stop terralist-rustfs-e2e-{{.TEST_RUN_ID}} terralist-mock-oauth2-e2e-{{.TEST_RUN_ID}}
-      - rm -f $TERRALIST_SQLITE_PATH
 
   test:unit:
     desc: "Run all unit tests."

--- a/e2e/frontend/markdown.spec.ts
+++ b/e2e/frontend/markdown.spec.ts
@@ -1,0 +1,150 @@
+import { test, expect, type Locator, type Page } from '@playwright/test';
+
+const gotoMarkdownFixture = async (page: Page): Promise<Locator> => {
+  await page.goto('/#/markdown-test');
+
+  await expect(page.getByText('Markdown rendering test')).toBeVisible({
+    timeout: 10_000,
+  });
+
+  const markdown = page.locator('.markdown-body');
+  await expect(markdown).toContainText('GitHub Flavored Markdown test');
+  return markdown;
+};
+
+const cssNumber = async (
+  locator: Locator,
+  property: string
+): Promise<number> => {
+  const value = await locator.evaluate(
+    (el, prop) => getComputedStyle(el).getPropertyValue(prop),
+    property
+  );
+
+  return Number.parseFloat(value);
+};
+
+test.describe('GitHub Flavored Markdown rendering', () => {
+  test('renders heading anchors, links, and duplicate slugs', async ({
+    page,
+  }) => {
+    const markdown = await gotoMarkdownFixture(page);
+
+    const h1 = markdown.locator('h1#h1-github-flavored-markdown-test');
+    await expect(h1).toContainText('H1 — GitHub Flavored Markdown test');
+    await expect(h1.locator('> a.heading-anchor')).toHaveAttribute(
+      'href',
+      '#/markdown-test?md-anchor=h1-github-flavored-markdown-test'
+    );
+
+    await expect(markdown.locator('h3#duplicate')).toBeVisible();
+    await expect(markdown.locator('h3#duplicate-1')).toBeVisible();
+
+    await expect(
+      markdown.getByRole('link', { name: 'Tables', exact: true })
+    ).toHaveAttribute('href', '#/markdown-test?md-anchor=tables');
+
+    const external = markdown.locator(
+      'a[href="https://github.com/terralist/terralist"]'
+    );
+    await expect(external).toHaveAttribute('target', '_blank');
+    await expect(external).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  test('renders GFM blocks and GitHub extensions', async ({ page }) => {
+    const markdown = await gotoMarkdownFixture(page);
+
+    await expect(markdown.locator('table')).toBeVisible();
+    await expect(markdown.locator('table th').first()).toContainText(
+      'Column A'
+    );
+    await expect(markdown.locator('table td code')).toContainText('code');
+    await expect(markdown.locator('table del')).toContainText('old');
+
+    const taskInputs = markdown.locator('input[type="checkbox"]');
+    await expect(taskInputs).toHaveCount(4);
+    await expect(taskInputs.nth(0)).toBeChecked();
+    await expect(taskInputs.nth(2)).not.toBeChecked();
+
+    for (const variant of [
+      'note',
+      'tip',
+      'important',
+      'warning',
+      'caution',
+    ]) {
+      await expect(
+        markdown.locator(`.markdown-alert-${variant}`)
+      ).toBeVisible();
+    }
+
+    await expect(markdown.locator('.footnotes')).toBeVisible();
+    await expect(markdown.locator('[data-footnote-ref]').first()).toBeVisible();
+    await expect(markdown.locator('.footnotes')).toContainText(
+      'This is the first footnote.'
+    );
+
+    await expect(markdown.locator('details summary')).toContainText(
+      'Click to expand'
+    );
+    await expect(markdown.locator('kbd').first()).toContainText('Cmd');
+    await expect(markdown).toContainText('🚀 launching');
+
+    await expect(markdown).toContainText("<script>alert('xss')</script>");
+    await expect(markdown.locator('script')).toHaveCount(0);
+  });
+
+  test('keeps markdown-specific CSS overrides applied', async ({ page }) => {
+    const markdown = await gotoMarkdownFixture(page);
+
+    await expect(markdown).toHaveCSS('border-radius', '4px');
+    expect(await cssNumber(markdown, 'padding-left')).toBeGreaterThan(0);
+
+    await expect(markdown.locator('h2#unordered-lists + ul')).toHaveCSS(
+      'list-style-type',
+      'disc'
+    );
+    await expect(markdown.locator('h2#ordered-lists + ol')).toHaveCSS(
+      'list-style-type',
+      'decimal'
+    );
+    await expect(
+      markdown.locator('h2#unordered-lists + ul ul').first()
+    ).toHaveCSS('list-style-type', 'circle');
+
+    const note = markdown.locator('.markdown-alert-note').first();
+    await expect(note).toHaveCSS('border-left-style', 'solid');
+    expect(await cssNumber(note, 'border-left-width')).toBeGreaterThanOrEqual(
+      3
+    );
+
+    const heading = markdown.locator('h2#headings');
+    const anchor = heading.locator('> a.heading-anchor');
+    await expect(anchor).toHaveCSS('opacity', '0');
+    await heading.hover();
+    await expect(anchor).toHaveCSS('opacity', '0.6');
+  });
+
+  test('mounts syntax-highlighted code blocks and Mermaid diagrams', async ({
+    page,
+  }) => {
+    const markdown = await gotoMarkdownFixture(page);
+
+    await expect(markdown.locator('.md-code-block')).toHaveCount(4, {
+      timeout: 10_000,
+    });
+    await expect(markdown.locator('.md-code-block .md-copy-btn')).toHaveCount(
+      4
+    );
+    await expect(markdown.locator('.md-code-block .shiki').first()).toBeVisible(
+      { timeout: 10_000 }
+    );
+    await expect(markdown.locator('.md-code-block').first()).toContainText(
+      'echo "hello, terralist"'
+    );
+
+    await expect(markdown.locator('.md-mermaid svg')).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+});

--- a/e2e/frontend/playwright.config.ts
+++ b/e2e/frontend/playwright.config.ts
@@ -25,7 +25,7 @@ export default defineConfig({
     },
     {
       name: 'authenticated',
-      testMatch: ['dashboard.spec.ts', 'settings.spec.ts'],
+      testMatch: ['dashboard.spec.ts', 'settings.spec.ts', 'markdown.spec.ts'],
       dependencies: ['setup'],
       use: {
         storageState: AUTH_STATE_PATH,

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/web/package.json
+++ b/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "test:unit": "vitest run",
     "format:write": "prettier --write **/*.ts",
     "format:check": "prettier --check **/*.ts",
     "lint:fix": "yarn exec eslint . -c eslint.config.mjs --fix",
@@ -47,7 +48,8 @@
     "typescript": "^5.8.2",
     "typescript-eslint": "^8.33.1",
     "uuid": "^13.0.0",
-    "vite": "^4.0.0"
+    "vite": "^4.0.0",
+    "vitest": "^0.34.6"
   },
   "dependencies": {
     "marked": "^15",

--- a/web/package.json
+++ b/web/package.json
@@ -39,7 +39,6 @@
     "svelte": "^4.2.19",
     "svelte-check": "^4.1.4",
     "svelte-eslint-parser": "^1.6.0",
-    "svelte-markdown": "^0.4.1",
     "svelte-spa-router": "^4.0.1",
     "svelte-system-info": "1.0.1",
     "svelte-use-click-outside": "1.0.0",
@@ -51,6 +50,10 @@
     "vite": "^4.0.0"
   },
   "dependencies": {
+    "marked": "^15",
+    "marked-alert": "^2",
+    "marked-footnote": "^1",
+    "marked-gfm-heading-id": "^4",
     "node-emoji": "^2.2.0"
   }
 }

--- a/web/src/components/Artifact.svelte
+++ b/web/src/components/Artifact.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
   import { onDestroy } from 'svelte';
   import { push } from 'svelte-spa-router';
-  import SvelteMarkdown from 'svelte-markdown';
 
   import context, { type Theme } from '@/context';
 
@@ -18,7 +17,7 @@
   import Dropdown from './Dropdown.svelte';
   import FullPageError from './FullPageError.svelte';
   import LoadingScreen from './LoadingScreen.svelte';
-  import MarkdownCode from './MarkdownCode.svelte';
+  import Markdown from './markdown/Markdown.svelte';
   import { emojify } from 'node-emoji';
 
   import {
@@ -254,13 +253,7 @@
           <div
             class="mt-6 p-4 border border-gray-300 dark:border-gray-600 rounded">
             <h3 class="text-md font-bold mb-2">{selectedSubmodule}</h3>
-            <div class="markdown-body">
-              <SvelteMarkdown
-                source={submoduleDocumentation}
-                renderers={{
-                  code: MarkdownCode
-                }} />
-            </div>
+            <Markdown source={submoduleDocumentation} />
           </div>
         {:else if selectedSubmodule}
           <div
@@ -282,15 +275,9 @@
           class="bg-gray-200 dark:bg-gray-700 border border-slate-400 dark:border-slate-600 p-3 text-xs overflow-y-auto">{template}</pre>
       </div>
       {#if documentation}
-        <div class="m-6 p-4 flex flex-col gap-4">
+        <div class="flex flex-col gap-4">
           <h2 class="text-lg font-bold">Readme</h2>
-          <div class="markdown-body">
-            <SvelteMarkdown
-              source={documentation}
-              renderers={{
-                code: MarkdownCode
-              }} />
-          </div>
+          <Markdown source={documentation} />
         </div>
       {/if}
     </section>

--- a/web/src/components/MarkdownCode.svelte
+++ b/web/src/components/MarkdownCode.svelte
@@ -33,8 +33,51 @@
 
   let codeEl: HTMLElement | null = null;
   let mermaidEl: HTMLElement | null = null;
-  let currentTheme: Theme = 'light';
-  const unsubscribe = context.theme.subscribe(t => (currentTheme = t));
+  let copied = false;
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const handleCopy = async (): Promise<void> => {
+    const value = text ?? '';
+    if (!value) return;
+    try {
+      if (
+        typeof navigator !== 'undefined' &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === 'function'
+      ) {
+        await navigator.clipboard.writeText(value);
+      } else {
+        // Fallback for environments without async clipboard (older Safari,
+        // insecure contexts). Uses a hidden textarea + execCommand.
+        const ta = document.createElement('textarea');
+        ta.value = value;
+        ta.setAttribute('readonly', '');
+        ta.style.position = 'absolute';
+        ta.style.left = '-9999px';
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand('copy');
+        document.body.removeChild(ta);
+      }
+      copied = true;
+      if (copyResetTimer) clearTimeout(copyResetTimer);
+      copyResetTimer = setTimeout(() => {
+        copied = false;
+      }, 1500);
+    } catch (err) {
+      console.error('Failed to copy code block to clipboard:', err);
+    }
+  };
+
+  // Auto-subscribe to the theme store so any `$:` block or template
+  // expression that references `$theme` is tracked by Svelte's reactivity.
+  const theme = context.theme;
+
+  // Monotonic token so a stale async highlight (spawned before a theme
+  // toggle) cannot overwrite a newer one. Without this, switching
+  // dark -> light can land on dark output when the older Shiki call
+  // resolves last.
+  let renderToken = 0;
 
   let shikiHighlighter: ShikiHighlighter | null = null;
   let mermaidFallback: MermaidApi | null = null;
@@ -101,67 +144,109 @@
     return mermaid || mermaidFallback;
   };
 
-  const applyHighlight = async () => {
+  const applyHighlight = async (activeTheme: Theme): Promise<void> => {
     if (!codeEl || !text) return;
-    codeEl.textContent = text ?? '';
+    const token = ++renderToken;
     try {
       const shikiInstance = shiki || (await ensureShiki());
-      if (shikiInstance) {
-        const theme = currentTheme === 'dark' ? 'github-dark' : 'github-light';
-        const html = await shikiInstance.codeToHtml(text, {
-          lang: lang || 'text',
-          theme,
-          transformers: []
-        });
-        codeEl.innerHTML = html;
-      }
+      if (token !== renderToken || !codeEl) return;
+      if (!shikiInstance) return;
+      const shikiTheme =
+        activeTheme === 'dark' ? 'github-dark' : 'github-light';
+      const html = await shikiInstance.codeToHtml(text, {
+        lang: lang || 'text',
+        theme: shikiTheme,
+        transformers: []
+      });
+      if (token !== renderToken || !codeEl) return;
+      codeEl.innerHTML = html;
     } catch (err) {
       console.error('Failed to highlight code block:', err);
     }
   };
 
-  const renderMermaid = async () => {
+  const renderMermaid = async (activeTheme: Theme): Promise<void> => {
     if (!mermaidEl || !text) return;
+    const token = ++renderToken;
     try {
       const mermaidInstance = mermaid || (await ensureMermaid());
-      if (mermaidInstance) {
-        mermaidInstance.initialize({
-          startOnLoad: false,
-          securityLevel: 'strict',
-          theme: currentTheme === 'dark' ? 'dark' : 'default'
-        });
+      if (token !== renderToken || !mermaidEl) return;
+      if (!mermaidInstance) return;
+      mermaidInstance.initialize({
+        startOnLoad: false,
+        securityLevel: 'strict',
+        theme: activeTheme === 'dark' ? 'dark' : 'default'
+      });
 
-        const id = `mmd-${Math.random().toString(36).slice(2)}`;
-        const { svg } = await mermaidInstance.render(id, text);
-        mermaidEl.innerHTML = svg;
-      }
+      const id = `mmd-${Math.random().toString(36).slice(2)}`;
+      const { svg } = await mermaidInstance.render(id, text);
+      if (token !== renderToken || !mermaidEl) return;
+      mermaidEl.innerHTML = svg;
     } catch (err) {
       console.error('Failed to render mermaid diagram:', err);
     }
   };
 
-  onMount(async () => {
-    if (lang === 'mermaid') {
-      await renderMermaid();
-    } else {
-      await applyHighlight();
-    }
+  let mounted = false;
+  onMount(() => {
+    mounted = true;
   });
 
-  // Trigger re-render when content or theme changes
-  $: {
+  onDestroy(() => {
+    if (copyResetTimer) clearTimeout(copyResetTimer);
+  });
+
+  // Re-render whenever the source, language, or theme changes. Guarded on
+  // `mounted` so we don't race with `bind:this` before the DOM node exists.
+  $: if (mounted) {
     if (lang === 'mermaid') {
-      renderMermaid();
+      renderMermaid($theme);
     } else if (text) {
-      applyHighlight();
+      applyHighlight($theme);
     }
   }
-
-  onDestroy(() => unsubscribe());
 </script>
 
 {#if lang === 'mermaid'}
-  <div class="mermaid" bind:this={mermaidEl}></div>
+  <div class="md-mermaid" bind:this={mermaidEl}></div>
 {:else}
-  <pre><code bind:this={codeEl}></code></pre>
+  <div class="md-code-block">
+    <button
+      class="md-copy-btn"
+      class:is-copied={copied}
+      type="button"
+      aria-label={copied ? 'Copied' : 'Copy code'}
+      title={copied ? 'Copied!' : 'Copy'}
+      on:click={handleCopy}>
+      {#if copied}
+        <svg
+          viewBox="0 0 16 16"
+          width="16"
+          height="16"
+          aria-hidden="true"
+          focusable="false">
+          <path
+            fill="currentColor"
+            d="M13.78 4.22a.75.75 0 0 1 0 1.06l-7.25 7.25a.75.75 0 0 1-1.06 0L2.22 9.28a.751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018L6 10.94l6.72-6.72a.75.75 0 0 1 1.06 0Z" />
+        </svg>
+      {:else}
+        <svg
+          viewBox="0 0 16 16"
+          width="16"
+          height="16"
+          aria-hidden="true"
+          focusable="false">
+          <path
+            fill="currentColor"
+            d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 0 1 0 1.5h-1.5a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-1.5a.75.75 0 0 1 1.5 0v1.5A1.75 1.75 0 0 1 9.25 16h-7.5A1.75 1.75 0 0 1 0 14.25Z" />
+          <path
+            fill="currentColor"
+            d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0 1 14.25 11h-7.5A1.75 1.75 0 0 1 5 9.25Zm1.75-.25a.25.25 0 0 0-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 0 0 .25-.25v-7.5a.25.25 0 0 0-.25-.25Z" />
+        </svg>
+      {/if}
+    </button>
+    <div class="md-code-content" bind:this={codeEl}>
+      <pre><code>{text ?? ''}</code></pre>
+    </div>
+  </div>
 {/if}

--- a/web/src/components/Navbar.svelte
+++ b/web/src/components/Navbar.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <header
-  class="fixed z-1 top-0 left-0 flex flex-col lg:flex-row items-center justify-center lg:justify-start lg:pl-4 w-full h-32 lg:h-16 bg-teal-400 dark:bg-teal-700 text-slate-600 dark:text-slate-200 box-border shadow">
+  class="fixed z-10 top-0 left-0 flex flex-col lg:flex-row items-center justify-center lg:justify-start lg:pl-4 w-full h-32 lg:h-16 bg-teal-400 dark:bg-teal-700 text-slate-600 dark:text-slate-200 box-border shadow">
   <button
     class="absolute top-0 left-0 grid place-items-center w-16 h-16 lg:hidden"
     on:click={toggle}>
@@ -63,7 +63,7 @@
   <nav
     class="
       fixed
-      z-3
+      z-30
       top-0
       left-0
       w-48

--- a/web/src/components/markdown/Markdown.svelte
+++ b/web/src/components/markdown/Markdown.svelte
@@ -86,9 +86,7 @@
     requestAnimationFrame(nudgeScroll);
     requestAnimationFrame(() => requestAnimationFrame(nudgeScroll));
     for (const delay of [120, 320, 720]) {
-      anchorFollowUpTimers.push(
-        setTimeout(nudgeScroll, delay)
-      );
+      anchorFollowUpTimers.push(setTimeout(nudgeScroll, delay));
     }
   };
 

--- a/web/src/components/markdown/Markdown.svelte
+++ b/web/src/components/markdown/Markdown.svelte
@@ -1,0 +1,108 @@
+<script lang="ts">
+  import { onDestroy, tick } from 'svelte';
+
+  import MarkdownCode from '@/components/MarkdownCode.svelte';
+  import {
+    CODE_PLACEHOLDER_CLASS,
+    decodeBase64Utf8,
+    render
+  } from '@/lib/markdown/render';
+
+  export let source: string;
+
+  let container: HTMLElement | null = null;
+  let mounted: Array<{ $destroy: () => void }> = [];
+
+  /**
+   * svelte-spa-router keeps the app path in `location.hash` as `#/route`.
+   * Plain fragment links (`href="#footnote-def-1"`, heading `#tables`, …)
+   * would replace that entire hash and kick the user off the current page.
+   * Intercept those and scroll inside the document instead.
+   */
+  const handleInDocHashClick = (e: MouseEvent): void => {
+    if (e.defaultPrevented || e.button !== 0) return;
+    if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+
+    const pathTarget = e.composedPath?.()[0] ?? e.target;
+    if (!(pathTarget instanceof Element)) return;
+    const anchor = pathTarget.closest('a');
+    if (!anchor || !(anchor instanceof HTMLAnchorElement)) return;
+
+    const raw = anchor.getAttribute('href');
+    if (raw == null) return;
+    const href = raw.trim();
+    if (!href.startsWith('#') || href.startsWith('#/')) return;
+    if (href === '#') return;
+
+    let id: string;
+    try {
+      id = decodeURIComponent(href.slice(1));
+    } catch {
+      return;
+    }
+    if (!id) return;
+
+    const el = document.getElementById(id);
+    if (!el) return;
+
+    e.preventDefault();
+    el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  };
+
+  $: html = render(source ?? '');
+
+  // Replace each `<div class="md-code-placeholder">` emitted by the marked
+  // renderer with a `MarkdownCode` Svelte component instance, so Shiki and
+  // Mermaid run for every code block. We tear down previously mounted
+  // components on each render to avoid leaks across source changes (theme
+  // toggles, version switches, etc.).
+  const mountCodeBlocks = async (): Promise<void> => {
+    await tick();
+    if (!container) return;
+
+    for (const instance of mounted) {
+      instance.$destroy();
+    }
+    mounted = [];
+
+    const placeholders = container.querySelectorAll<HTMLElement>(
+      `.${CODE_PLACEHOLDER_CLASS}`
+    );
+    placeholders.forEach(placeholder => {
+      const lang = placeholder.dataset.mdLang || undefined;
+      const text = decodeBase64Utf8(placeholder.dataset.mdCode ?? '');
+
+      const target = document.createElement('div');
+      target.className = 'md-code-mount';
+      placeholder.replaceWith(target);
+
+      mounted.push(
+        new MarkdownCode({
+          target,
+          props: { lang, text }
+        })
+      );
+    });
+  };
+
+  $: {
+    void html;
+    void mountCodeBlocks();
+  }
+
+  onDestroy(() => {
+    for (const instance of mounted) {
+      instance.$destroy();
+    }
+    mounted = [];
+  });
+</script>
+
+<!-- svelte-ignore a11y-click-events-have-key-events a11y-no-static-element-interactions -->
+<div
+  class="markdown-body"
+  bind:this={container}
+  on:click|capture={handleInDocHashClick}>
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+  {@html html}
+</div>

--- a/web/src/components/markdown/Markdown.svelte
+++ b/web/src/components/markdown/Markdown.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { onDestroy, tick } from 'svelte';
+  import { get } from 'svelte/store';
+  import { location, querystring } from 'svelte-spa-router';
 
   import MarkdownCode from '@/components/MarkdownCode.svelte';
   import {
     CODE_PLACEHOLDER_CLASS,
     decodeBase64Utf8,
+    MD_ANCHOR_QUERY,
     render
   } from '@/lib/markdown/render';
 
@@ -12,6 +15,82 @@
 
   let container: HTMLElement | null = null;
   let mounted: Array<{ $destroy: () => void }> = [];
+  /** Skip tearing down Shiki/Mermaid when only `?md-anchor=` changed. */
+  let lastMountedHtml: string | null = null;
+  let highlightedForAnchor: Element | null = null;
+  /** Cancels in-flight deep-link scroll when the component tears down or deps change. */
+  let anchorScrollGeneration = 0;
+  const anchorFollowUpTimers: ReturnType<typeof setTimeout>[] = [];
+
+  const clearAnchorFollowUpTimers = (): void => {
+    for (const t of anchorFollowUpTimers) {
+      clearTimeout(t);
+    }
+    anchorFollowUpTimers.length = 0;
+  };
+
+  const clearMdAnchorHighlight = (): void => {
+    highlightedForAnchor?.classList.remove('md-anchor-target');
+    highlightedForAnchor = null;
+  };
+
+  const scrollElToView = (el: HTMLElement): void => {
+    el.scrollIntoView({ behavior: 'auto', block: 'start' });
+  };
+
+  /**
+   * After a cold open, headings exist in `{@html}` but the target may not be
+   * in the DOM yet (async route), or layout shifts once Shiki/Mermaid paint.
+   * Retry until the id appears, then nudge scroll a few times as layout settles.
+   */
+  const scrollToMdAnchorFromQuery = async (): Promise<void> => {
+    const generation = ++anchorScrollGeneration;
+    clearAnchorFollowUpTimers();
+    clearMdAnchorHighlight();
+
+    let id: string | null = null;
+    try {
+      id = new URLSearchParams(get(querystring) ?? '').get(MD_ANCHOR_QUERY);
+      if (id) id = decodeURIComponent(id);
+    } catch {
+      id = null;
+    }
+    if (!id) return;
+
+    const maxWaitMs = 4000;
+    const stepMs = 32;
+    const deadline = Date.now() + maxWaitMs;
+
+    let el: HTMLElement | null = null;
+    while (Date.now() < deadline && generation === anchorScrollGeneration) {
+      await tick();
+      el = document.getElementById(id);
+      if (el) break;
+      await new Promise<void>(r => setTimeout(r, stepMs));
+    }
+
+    if (generation !== anchorScrollGeneration || !el) return;
+
+    const anchorId = id;
+    highlightedForAnchor = el;
+    el.classList.add('md-anchor-target');
+
+    const nudgeScroll = (): void => {
+      if (generation !== anchorScrollGeneration) return;
+      const node = document.getElementById(anchorId);
+      if (!node) return;
+      scrollElToView(node);
+    };
+
+    nudgeScroll();
+    requestAnimationFrame(nudgeScroll);
+    requestAnimationFrame(() => requestAnimationFrame(nudgeScroll));
+    for (const delay of [120, 320, 720]) {
+      anchorFollowUpTimers.push(
+        setTimeout(nudgeScroll, delay)
+      );
+    }
+  };
 
   /**
    * svelte-spa-router keeps the app path in `location.hash` as `#/route`.
@@ -49,7 +128,7 @@
     el.scrollIntoView({ behavior: 'smooth', block: 'start' });
   };
 
-  $: html = render(source ?? '');
+  $: html = render(source ?? '', { routePath: $location ?? '' });
 
   // Replace each `<div class="md-code-placeholder">` emitted by the marked
   // renderer with a `MarkdownCode` Svelte component instance, so Shiki and
@@ -60,41 +139,53 @@
     await tick();
     if (!container) return;
 
-    for (const instance of mounted) {
-      instance.$destroy();
-    }
-    mounted = [];
+    const htmlChanged = lastMountedHtml !== html;
+    if (htmlChanged) {
+      lastMountedHtml = html;
+      for (const instance of mounted) {
+        instance.$destroy();
+      }
+      mounted = [];
 
-    const placeholders = container.querySelectorAll<HTMLElement>(
-      `.${CODE_PLACEHOLDER_CLASS}`
-    );
-    placeholders.forEach(placeholder => {
-      const lang = placeholder.dataset.mdLang || undefined;
-      const text = decodeBase64Utf8(placeholder.dataset.mdCode ?? '');
-
-      const target = document.createElement('div');
-      target.className = 'md-code-mount';
-      placeholder.replaceWith(target);
-
-      mounted.push(
-        new MarkdownCode({
-          target,
-          props: { lang, text }
-        })
+      const placeholders = container.querySelectorAll<HTMLElement>(
+        `.${CODE_PLACEHOLDER_CLASS}`
       );
-    });
+      placeholders.forEach(placeholder => {
+        const lang = placeholder.dataset.mdLang || undefined;
+        const text = decodeBase64Utf8(placeholder.dataset.mdCode ?? '');
+
+        const target = document.createElement('div');
+        target.className = 'md-code-mount';
+        placeholder.replaceWith(target);
+
+        mounted.push(
+          new MarkdownCode({
+            target,
+            props: { lang, text }
+          })
+        );
+      });
+    }
+
+    await tick();
+    void scrollToMdAnchorFromQuery();
   };
 
   $: {
     void html;
+    void $querystring;
     void mountCodeBlocks();
   }
 
   onDestroy(() => {
+    anchorScrollGeneration += 1;
+    clearAnchorFollowUpTimers();
+    clearMdAnchorHighlight();
     for (const instance of mounted) {
       instance.$destroy();
     }
     mounted = [];
+    lastMountedHtml = null;
   });
 </script>
 

--- a/web/src/lib/markdown/render.test.ts
+++ b/web/src/lib/markdown/render.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import { CODE_PLACEHOLDER_CLASS, decodeBase64Utf8, render } from './render';
+
+describe('render', () => {
+  it('renders heading anchors with duplicate GitHub-style ids', (): void => {
+    const html = render('# Title\n\n## Title', { routePath: '/markdown-test' });
+
+    expect(html).toContain('<h1 id="title" class="markdown-heading">');
+    expect(html).toContain(
+      '<a class="heading-anchor" href="#/markdown-test?md-anchor=title"'
+    );
+    expect(html).toContain('<h2 id="title-1" class="markdown-heading">');
+    expect(html).toContain(
+      '<a class="heading-anchor" href="#/markdown-test?md-anchor=title-1"'
+    );
+  });
+
+  it('renders common GFM blocks and inline extensions', (): void => {
+    const html = render(`
+| Feature | Status |
+| ------- | ------ |
+| Tables | yes |
+
+- [x] checked
+- [ ] unchecked
+
+~~removed~~
+https://example.com
+`);
+
+    expect(html).toContain('<table>');
+    expect(html).toContain('<th>Feature</th>');
+    expect(html).toMatch(/<input[^>]*checked[^>]*>/);
+    expect(html).toContain('type="checkbox"');
+    expect(html).toContain('<del>removed</del>');
+    expect(html).toContain('<a href="https://example.com"');
+  });
+
+  it('renders GitHub alert and footnote extensions', (): void => {
+    const html = render(`
+> [!NOTE]
+> Useful context.
+
+Footnote reference[^one].
+
+[^one]: Footnote body.
+`);
+
+    expect(html).toContain('markdown-alert markdown-alert-note');
+    expect(html).toContain('markdown-alert-title');
+    expect(html).toContain('data-footnote-ref');
+    expect(html).toContain('class="footnotes"');
+    expect(html).toContain('Footnote body.');
+  });
+
+  it('sanitizes unsafe links and annotates external links', (): void => {
+    const html = render(
+      '[bad](javascript:alert(1)) [ok](https://example.com "Example")'
+    );
+
+    expect(html).not.toContain('javascript:');
+    expect(html).toContain('bad');
+    expect(html).toContain(
+      '<a href="https://example.com" title="Example" target="_blank" rel="noopener noreferrer">ok</a>'
+    );
+  });
+
+  it('escapes GFM disallowed raw HTML tags', (): void => {
+    const html = render("<script>alert('xss')</script>");
+
+    expect(html).toContain("&lt;script>alert('xss')&lt;/script>");
+    expect(html).not.toContain("<script>alert('xss')</script>");
+  });
+
+  it('emits UTF-8-safe code placeholders for Svelte mounting', (): void => {
+    const html = render('```ts copy\nconsole.log("sparkles ✨");\n```');
+    const codeAttr = html.match(/data-md-code="([^"]+)"/)?.[1];
+
+    expect(html).toContain(`class="${CODE_PLACEHOLDER_CLASS}"`);
+    expect(html).toContain('data-md-lang="ts"');
+    expect(codeAttr).toBeDefined();
+    expect(decodeBase64Utf8(codeAttr ?? '')).toBe(
+      'console.log("sparkles ✨");'
+    );
+  });
+
+  it('rewrites in-document fragments for SPA hash routing', (): void => {
+    const html = render('[Tables](#tables) [Route](#/settings)', {
+      routePath: 'markdown-test'
+    });
+
+    expect(html).toContain('href="#/markdown-test?md-anchor=tables"');
+    expect(html).toContain('href="#/settings"');
+  });
+});

--- a/web/src/lib/markdown/render.ts
+++ b/web/src/lib/markdown/render.ts
@@ -1,0 +1,178 @@
+import { Marked, type Token } from 'marked';
+import markedAlert from 'marked-alert';
+import markedFootnote from 'marked-footnote';
+
+import { Slugger } from './slugger';
+
+/**
+ * Subset of the marked renderer `this` we rely on inside our overrides.
+ * marked v15's renderer functions are bound to the parser via `this`; the
+ * official typings infer this only when classes extend `Renderer`, so we
+ * spell it out for our object-literal overrides.
+ */
+type RendererThis = { parser: { parseInline: (tokens: Token[]) => string } };
+
+/**
+ * SVG octicon GitHub uses for the heading anchor link icon.
+ */
+const ANCHOR_SVG =
+  '<svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" focusable="false">' +
+  '<path fill="currentColor" d="m7.775 3.275 1.25-1.25a3.5 3.5 0 1 1 4.95 4.95l-2.5 2.5a3.5 3.5 0 0 1-4.95 0 .751.751 0 0 1 .018-1.042.751.751 0 0 1 1.042-.018 1.998 1.998 0 0 0 2.83 0l2.5-2.5a2.002 2.002 0 0 0-2.83-2.83l-1.25 1.25a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042Zm-4.69 9.64a1.998 1.998 0 0 0 2.83 0l1.25-1.25a.751.751 0 0 1 1.042.018.751.751 0 0 1 .018 1.042l-1.25 1.25a3.5 3.5 0 1 1-4.95-4.95l2.5-2.5a3.5 3.5 0 0 1 4.95 0 .751.751 0 0 1-.018 1.042.751.751 0 0 1-1.042.018 1.998 1.998 0 0 0-2.83 0l-2.5 2.5a1.998 1.998 0 0 0 0 2.83Z"/>' +
+  '</svg>';
+
+const escapeAttr = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+
+const stripHtml = (html: string): string => html.replace(/<[^>]*>/g, '').trim();
+
+/**
+ * GFM "Disallowed Raw HTML" extension (spec section 6.11). Replaces the
+ * leading `<` of any disallowed tag with `&lt;` so it renders as literal
+ * text rather than executing. Operates on the final HTML, after marked has
+ * already escaped content inside code blocks and inline code.
+ */
+const DISALLOWED_RAW_HTML_RE =
+  /<(\/?)(title|textarea|style|xmp|iframe|noembed|noframes|script|plaintext)(?=[\s/>])/gi;
+
+const stripDisallowedRawHtml = (html: string): string =>
+  html.replace(DISALLOWED_RAW_HTML_RE, '&lt;$1$2');
+
+/**
+ * Allowlist of URL schemes considered safe for `<a href>`. Prevents
+ * `javascript:` / `data:` / `vbscript:` URLs from sneaking through user
+ * markdown.
+ */
+const SAFE_URL_RE =
+  /^(?:https?:|mailto:|tel:|ftp:|sftp:|ssh:|git:|#|\/|\.\/|\.\.\/)/i;
+
+const sanitizeHref = (href: string): string => {
+  const trimmed = href.trim();
+  if (!trimmed) return '';
+  // Treat scheme-relative protocol as http/https, which is safe.
+  if (trimmed.startsWith('//')) return trimmed;
+  if (SAFE_URL_RE.test(trimmed)) return trimmed;
+  // Allow bare relative paths like "foo/bar" or "foo.md".
+  if (!/^[a-z][a-z0-9+.-]*:/i.test(trimmed)) return trimmed;
+  return '';
+};
+
+/**
+ * Encode arbitrary UTF-8 code into a safe base64 string for embedding inside
+ * an HTML attribute. Plain `btoa` would throw on non-Latin-1 input.
+ */
+const encodeBase64Utf8 = (text: string): string => {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary);
+};
+
+/**
+ * Inverse of {@link encodeBase64Utf8}, used by the Markdown component when it
+ * mounts a `MarkdownCode` Svelte component into a code-block placeholder.
+ */
+export const decodeBase64Utf8 = (encoded: string): string => {
+  const binary = atob(encoded);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+};
+
+/**
+ * CSS class used as a marker on the placeholder elements emitted by the code
+ * renderer. The Markdown component finds them and mounts a `MarkdownCode`
+ * Svelte component (which handles Shiki + Mermaid) into each one.
+ */
+export const CODE_PLACEHOLDER_CLASS = 'md-code-placeholder';
+
+/**
+ * Render Markdown to HTML using the full GitHub Flavored Markdown feature
+ * set:
+ *
+ *   - CommonMark base (paragraphs, emphasis, code, lists, links, images,
+ *     blockquotes, raw HTML, hard breaks, etc.).
+ *   - GFM extensions: tables, strikethrough, task list items, autolinks,
+ *     disallowed raw HTML (handled by marked's default escaping).
+ *   - GitHub additions on top of GFM that READMEs commonly use:
+ *       - Heading anchor links (custom heading renderer + Slugger).
+ *       - Alerts (`> [!NOTE]`, `> [!TIP]`, ...) via `marked-alert`.
+ *       - Footnotes (`[^1]` / `[^1]: ...`) via `marked-footnote`.
+ *       - External link safety (`target="_blank" rel="noopener noreferrer"`).
+ *   - Code blocks are emitted as placeholder elements that the Svelte
+ *     wrapper replaces with `MarkdownCode` instances so Shiki and Mermaid
+ *     can run client-side.
+ *
+ * A fresh `Marked` instance and `Slugger` are created on every call so that
+ * heading IDs and footnote numbering are scoped to a single document and do
+ * not leak across renders.
+ */
+export const render = (source: string): string => {
+  const slugger = new Slugger();
+  const marked = new Marked({ gfm: true, breaks: false });
+
+  marked.use(
+    markedAlert(),
+    markedFootnote({ refMarkers: true, footnoteDivider: true })
+  );
+
+  marked.use({
+    hooks: {
+      postprocess(html: string): string {
+        return stripDisallowedRawHtml(html);
+      }
+    },
+    renderer: {
+      heading(this: RendererThis, { tokens, depth }) {
+        // Render the heading's inline content first so we can derive a slug
+        // from the plain text and use the rendered HTML as the visible label.
+        const innerHtml = this.parser.parseInline(tokens);
+        const rawText = stripHtml(innerHtml);
+        const id = slugger.slug(rawText);
+        const aria = escapeAttr(`Permalink to ${rawText}`);
+        const safeId = escapeAttr(id);
+        return (
+          `<h${depth} id="${safeId}" class="markdown-heading">` +
+          `<a class="heading-anchor" href="#${safeId}" aria-label="${aria}">${ANCHOR_SVG}</a>` +
+          innerHtml +
+          `</h${depth}>\n`
+        );
+      },
+      link(this: RendererThis, { href, title, tokens }) {
+        const text = this.parser.parseInline(tokens);
+        const safeHref = sanitizeHref(href);
+        if (!safeHref) {
+          // Drop the link entirely if the URL was unsafe; render plain text.
+          return text;
+        }
+        const isExternal = /^(https?:)?\/\//i.test(safeHref);
+        const titleAttr = title ? ` title="${escapeAttr(title)}"` : '';
+        const externalAttrs = isExternal
+          ? ' target="_blank" rel="noopener noreferrer"'
+          : '';
+        return `<a href="${escapeAttr(safeHref)}"${titleAttr}${externalAttrs}>${text}</a>`;
+      },
+      code({ text, lang }) {
+        // Take just the first whitespace-delimited token; some sources write
+        // ```ts copy``` etc. to attach extra metadata.
+        const safeLang = (lang ?? '').split(/\s+/)[0] ?? '';
+        const encoded = encodeBase64Utf8(text);
+        return (
+          `<div class="${CODE_PLACEHOLDER_CLASS}"` +
+          ` data-md-lang="${escapeAttr(safeLang)}"` +
+          ` data-md-code="${encoded}"></div>\n`
+        );
+      }
+    }
+  });
+
+  return marked.parse(source, { async: false });
+};

--- a/web/src/lib/markdown/render.ts
+++ b/web/src/lib/markdown/render.ts
@@ -95,6 +95,41 @@ export const decodeBase64Utf8 = (encoded: string): string => {
 export const CODE_PLACEHOLDER_CLASS = 'md-code-placeholder';
 
 /**
+ * Query key used with svelte-spa-router's hash URLs (`#/path?...`) so
+ * in-document anchors are shareable. HTML only allows one `#fragment`; the
+ * app route already occupies the hash (`#/markdown-test`), so heading and
+ * footnote links are rewritten to `#/current/path?md-anchor=<id>`.
+ */
+export const MD_ANCHOR_QUERY = 'md-anchor';
+
+export type RenderOptions = {
+  /** SPA path from `location` (e.g. `/markdown-test`). When set, `href="#id"` links become shareable hash+query URLs. */
+  routePath?: string | null;
+};
+
+const normalizeRoutePath = (routePath: string): string =>
+  routePath.startsWith('/') ? routePath : `/${routePath}`;
+
+/**
+ * Rewrite `<a href="#fragment">` (not `#/…` routes) to
+ * `#<routePath>?md-anchor=<encoded-fragment>` so links survive hash routing.
+ */
+const rewriteFragmentLinksForSpaHash = (
+  html: string,
+  routePath: string
+): string => {
+  const path = normalizeRoutePath(routePath.trim());
+  const prefix = `#${path}?${MD_ANCHOR_QUERY}=`;
+  return html.replace(
+    /href="#(?!\/)([^"#]*)"/gi,
+    (_m, fragment: string) =>
+      fragment
+        ? `href="${prefix}${encodeURIComponent(fragment)}"`
+        : 'href="#"'
+  );
+};
+
+/**
  * Render Markdown to HTML using the full GitHub Flavored Markdown feature
  * set:
  *
@@ -114,8 +149,13 @@ export const CODE_PLACEHOLDER_CLASS = 'md-code-placeholder';
  * A fresh `Marked` instance and `Slugger` are created on every call so that
  * heading IDs and footnote numbering are scoped to a single document and do
  * not leak across renders.
+ *
+ * @param options.routePath When set (typically `$location` from svelte-spa-router),
+ *   same-document anchors become `#/path?md-anchor=id` so shared URLs open the
+ *   correct route and scroll to the target.
  */
-export const render = (source: string): string => {
+export const render = (source: string, options?: RenderOptions): string => {
+  const routePath = options?.routePath?.trim() ?? '';
   const slugger = new Slugger();
   const marked = new Marked({ gfm: true, breaks: false });
 
@@ -127,7 +167,11 @@ export const render = (source: string): string => {
   marked.use({
     hooks: {
       postprocess(html: string): string {
-        return stripDisallowedRawHtml(html);
+        let out = stripDisallowedRawHtml(html);
+        if (routePath) {
+          out = rewriteFragmentLinksForSpaHash(out, routePath);
+        }
+        return out;
       }
     },
     renderer: {

--- a/web/src/lib/markdown/render.ts
+++ b/web/src/lib/markdown/render.ts
@@ -120,12 +120,8 @@ const rewriteFragmentLinksForSpaHash = (
 ): string => {
   const path = normalizeRoutePath(routePath.trim());
   const prefix = `#${path}?${MD_ANCHOR_QUERY}=`;
-  return html.replace(
-    /href="#(?!\/)([^"#]*)"/gi,
-    (_m, fragment: string) =>
-      fragment
-        ? `href="${prefix}${encodeURIComponent(fragment)}"`
-        : 'href="#"'
+  return html.replace(/href="#(?!\/)([^"#]*)"/gi, (_m, fragment: string) =>
+    fragment ? `href="${prefix}${encodeURIComponent(fragment)}"` : 'href="#"'
   );
 };
 

--- a/web/src/lib/markdown/sample.ts
+++ b/web/src/lib/markdown/sample.ts
@@ -1,0 +1,198 @@
+/**
+ * Reasonably exhaustive GitHub Flavored Markdown fixture. Rendered at
+ * `/markdown-test`, this exercises every feature the Terralist markdown
+ * pipeline is expected to support so visual regressions are obvious.
+ *
+ * Sections are ordered to roughly mirror the GFM spec
+ * (https://github.github.com/gfm/) followed by the extensions GitHub layers
+ * on top (alerts, footnotes, emoji, mermaid).
+ */
+export const markdownSample = `# H1 — GitHub Flavored Markdown test
+
+This page exercises the markdown renderer end-to-end. Compare it against the
+same source rendered on github.com to spot regressions.
+
+## Inline formatting
+
+Plain text with **bold**, *italic*, ***bold italic***, ~~strikethrough~~,
+\`inline code\`, sub<sub>script</sub>, sup<sup>erscript</sup>, and a hard
+line break:
+line one\\
+line two.
+
+Escapes work too: \\*not italic\\* and \\\`not code\\\`.
+
+---
+
+## Headings
+
+Each heading should show a link icon when hovered. Duplicate names should get
+unique anchors (e.g. \`#duplicate\`, \`#duplicate-1\`).
+
+### Duplicate
+### Duplicate
+#### H4 example
+##### H5 example
+###### H6 example
+
+## Links and autolinks
+
+- Markdown link: [Terralist](https://github.com/terralist/terralist)
+- Title attribute: [hover me](https://terraform.io "Go to terraform.io")
+- Internal anchor: [Tables](#tables)
+- Relative path: [Dashboard](/)
+- Bare URL autolink: https://github.com
+- Angle-bracket autolink: <https://www.hashicorp.com>
+- Email autolink: <support@example.com>
+
+External links should open in a new tab; in-doc links should not.
+
+## Images
+
+![Terralist logo](/terralist.svg "Terralist logo")
+
+## Unordered lists
+
+- Item one
+- Item two
+  - Nested item A
+  - Nested item B
+    - Deep nested item
+- Item three
+
+## Ordered lists
+
+1. First step
+2. Second step
+   1. Sub-step
+   2. Another sub-step
+3. Third step
+
+## Task lists
+
+- [x] Completed task with **bold** and \`code\`
+- [x] Another completed task
+- [ ] Outstanding task
+- [ ] Task with a [link](https://example.com)
+
+## Tables
+
+| Column A | Column B  | Column C |
+| :------- | :-------: | -------: |
+| left     | center    |    right |
+| \`code\`   | **bold**  | *italic* |
+| 1        | 2         |        3 |
+| ~~old~~  | new       | https://example.com |
+
+## Blockquotes
+
+> A simple blockquote.
+>
+> With multiple paragraphs and **inline formatting**.
+>
+> > And a nested blockquote.
+
+## GFM alerts
+
+> [!NOTE]
+> Highlights information that users should take into account, even when
+> skimming.
+
+> [!TIP]
+> Optional information to help a user be more successful.
+
+> [!IMPORTANT]
+> Crucial information necessary for users to succeed.
+
+> [!WARNING]
+> Critical content demanding immediate user attention due to potential risks.
+
+> [!CAUTION]
+> Negative potential consequences of an action.
+
+## Code blocks
+
+Inline: \`terraform init\`.
+
+### Bash code block
+\`\`\`bash
+# A bash block
+echo "hello, terralist"
+for i in 1 2 3; do
+  echo "iteration $i"
+done
+\`\`\`
+
+### HCL code block
+\`\`\`hcl
+resource "aws_s3_bucket" "example" {
+  bucket = "my-tf-test-bucket"
+
+  tags = {
+    Name        = "My bucket"
+    Environment = "Dev"
+  }
+}
+\`\`\`
+
+### JSON code block
+\`\`\`json
+{
+  "name": "terralist",
+  "version": "1.0.0",
+  "features": ["modules", "providers"]
+}
+\`\`\`
+
+### Mermaid code block
+\`\`\`mermaid
+flowchart LR
+  A[Client] --> B{Auth?}
+  B -- yes --> C[Terralist API]
+  B -- no  --> D[401]
+  C --> E[(Storage)]
+\`\`\`
+
+A code block without a language should still render as a plain block:
+
+\`\`\`
+no language tag here
+\`\`\`
+
+## Horizontal rule
+
+---
+
+## Footnotes
+
+Here is a simple footnote[^1]. With some additional text after it[^longer]
+and without disrupting the surrounding blocks.
+
+[^1]: This is the first footnote.
+[^longer]: A longer footnote with **inline formatting**, a [link](https://github.com),
+    and a second paragraph.
+
+    > Even a blockquote inside the footnote.
+
+## HTML pass-through
+
+<details>
+<summary>Click to expand</summary>
+
+Hidden content with **markdown** still rendered inside.
+
+</details>
+
+<kbd>Cmd</kbd> + <kbd>K</kbd> chord rendered with raw HTML.
+
+## Emoji shortcodes
+
+:rocket: launching, :sparkles: looking shiny, :white_check_mark: validated.
+
+## Disallowed raw HTML
+
+GFM strips dangerous tags such as \`<script>\` and \`<iframe>\`. The
+following should render as escaped text rather than executing:
+
+<script>alert('xss')</script>
+`;

--- a/web/src/lib/markdown/slugger.test.ts
+++ b/web/src/lib/markdown/slugger.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { Slugger } from './slugger';
+
+describe('Slugger', () => {
+  it('generates GitHub-style heading slugs', (): void => {
+    const slugger = new Slugger();
+
+    expect(slugger.slug('  GitHub Flavored Markdown!  ')).toBe(
+      'github-flavored-markdown'
+    );
+    expect(slugger.slug('Multiple    spaces---collapse')).toBe(
+      'multiple-spaces-collapse'
+    );
+  });
+
+  it('deduplicates repeated slugs on the same instance', (): void => {
+    const slugger = new Slugger();
+
+    expect(slugger.slug('Duplicate')).toBe('duplicate');
+    expect(slugger.slug('Duplicate')).toBe('duplicate-1');
+    expect(slugger.slug('Duplicate')).toBe('duplicate-2');
+  });
+
+  it('can reset duplicate tracking', (): void => {
+    const slugger = new Slugger();
+
+    expect(slugger.slug('Duplicate')).toBe('duplicate');
+    expect(slugger.slug('Duplicate')).toBe('duplicate-1');
+
+    slugger.reset();
+
+    expect(slugger.slug('Duplicate')).toBe('duplicate');
+  });
+});

--- a/web/src/lib/markdown/slugger.ts
+++ b/web/src/lib/markdown/slugger.ts
@@ -1,0 +1,31 @@
+/**
+ * Generates URL-safe slugs for headings, ensuring uniqueness across calls
+ * on the same instance. Mirrors the algorithm GitHub uses for heading anchors,
+ * so links match what users expect when copying anchors from rendered docs.
+ */
+export class Slugger {
+  private readonly seen = new Map<string, number>();
+
+  slug(value: string): string {
+    const base = value
+      .toLowerCase()
+      .trim()
+      .replace(/<[!/a-z].*?>/gi, '')
+      .replace(
+        // eslint-disable-next-line no-useless-escape
+        /[\u2000-\u206F\u2E00-\u2E7F\\'!"#$%&()*+,./:;<=>?@\[\]^`{|}~]/g,
+        ''
+      )
+      .replace(/\s+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '');
+
+    const count = this.seen.get(base) ?? 0;
+    this.seen.set(base, count + 1);
+    return count === 0 ? base : `${base}-${count}`;
+  }
+
+  reset(): void {
+    this.seen.clear();
+  }
+}

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -230,20 +230,11 @@
   margin-bottom: 1rem;
 }
 
-/*
- * Strip the github-markdown-css `pre` styling (background, padding, margin,
- * 85% font size) from the Shiki-rendered `pre`. We need `!important` because
- * github-markdown-css is injected via `<svelte:head>` after main.css and
- * therefore wins on equal specificity, and Shiki sets the background via an
- * inline `style` attribute which can only be defeated with `!important`.
- */
-.markdown-body .md-code-block pre,
-.markdown-body .md-code-block pre code,
-.markdown-body .md-code-block .md-code-content,
-.markdown-body .md-code-block .md-code-content > pre {
-  background: transparent !important;
-  margin: 0 !important;
-  padding: 0 !important;
+.md-code-block .github-light {
+  background-color: #f6f8fa !important; 
+}
+.md-code-block .github-dark {
+  background-color: #151b23 !important;
 }
 
 .markdown-body code,

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -106,7 +106,8 @@
   scroll-margin-top: 5rem;
 }
 
-.markdown-body .footnotes li:target {
+.markdown-body .footnotes li:target,
+.markdown-body .footnotes li.md-anchor-target {
   background-color: rgba(255, 211, 61, 0.2);
 }
 

--- a/web/src/main.css
+++ b/web/src/main.css
@@ -1,3 +1,324 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/*
+ * GitHub Flavored Markdown overrides.
+ *
+ * github-markdown-css ships most of the GitHub look, but we still need to
+ * fill a few gaps:
+ *
+ *   1. Tailwind's preflight resets `ul`/`ol` to `list-style: none; padding:
+ *      0`, and github-markdown-css does not re-assert disc/decimal at the top
+ *      level, so list bullets disappear without these rules.
+ *   2. Heading anchor link icon (rendered by our marked heading renderer).
+ *   3. Footnotes (rendered by `marked-footnote`).
+ *   4. GFM alerts (rendered by `marked-alert`).
+ *   5. Internal padding so the heading anchor (positioned at `left: -1.25em`
+ *      of the heading) and other edge-aligned content sit inside the panel
+ *      that github-markdown-css's background paints.
+ */
+.markdown-body {
+  padding: 1.5rem 2rem;
+  border-radius: 0.25rem;
+}
+
+.markdown-body ul {
+  list-style: disc outside;
+  padding-left: 2em;
+}
+
+.markdown-body ol {
+  list-style: decimal outside;
+  padding-left: 2em;
+}
+
+.markdown-body ul ul,
+.markdown-body ol ul {
+  list-style-type: circle;
+}
+
+.markdown-body ul ul ul,
+.markdown-body ol ul ul,
+.markdown-body ul ol ul,
+.markdown-body ol ol ul {
+  list-style-type: square;
+}
+
+.markdown-body li + li {
+  margin-top: 0.25em;
+}
+
+.markdown-body .task-list-item {
+  list-style-type: none;
+  margin-left: -1.5em;
+}
+
+.markdown-body .task-list-item input[type='checkbox'] {
+  margin: 0 0.4em 0.25em -1.4em;
+  vertical-align: middle;
+}
+
+/* Heading anchor link icon, shown on hover/focus like github.com renders. */
+.markdown-body .markdown-heading {
+  position: relative;
+  scroll-margin-top: 5rem;
+}
+
+.markdown-body .markdown-heading .heading-anchor {
+  position: absolute;
+  left: -1.25em;
+  top: 50%;
+  transform: translateY(-50%);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1em;
+  height: 1em;
+  color: inherit;
+  text-decoration: none;
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+}
+
+.markdown-body .markdown-heading:hover .heading-anchor,
+.markdown-body .markdown-heading .heading-anchor:focus {
+  opacity: 0.6;
+}
+
+.markdown-body .markdown-heading .heading-anchor:hover {
+  opacity: 1;
+}
+
+/* Footnotes (marked-footnote). */
+.markdown-body .footnotes {
+  font-size: 0.875em;
+  border-top: 1px solid var(--color-border-default, #d0d7de);
+  margin-top: 2rem;
+  padding-top: 1rem;
+}
+
+.markdown-body .footnotes ol {
+  padding-left: 1.5em;
+}
+
+.markdown-body .footnotes li {
+  scroll-margin-top: 5rem;
+}
+
+.markdown-body .footnotes li:target {
+  background-color: rgba(255, 211, 61, 0.2);
+}
+
+.markdown-body sup [data-footnote-ref]::before {
+  content: '[';
+}
+
+.markdown-body sup [data-footnote-ref]::after {
+  content: ']';
+}
+
+/* GFM alerts (marked-alert). Defaults match github.com's color tokens for
+ * both light and dark themes. */
+.markdown-body .markdown-alert {
+  padding: 0.5rem 1rem;
+  margin-bottom: 1rem;
+  border-left: 0.25em solid;
+  color: inherit;
+  background-color: transparent;
+}
+
+.markdown-body .markdown-alert > :first-child {
+  margin-top: 0;
+}
+
+.markdown-body .markdown-alert > :last-child {
+  margin-bottom: 0;
+}
+
+.markdown-body .markdown-alert .markdown-alert-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+  line-height: 1;
+}
+
+.markdown-body .markdown-alert-note {
+  border-left-color: #0969da;
+}
+
+.markdown-body .markdown-alert-tip {
+  border-left-color: #1a7f37;
+}
+
+.markdown-body .markdown-alert-important {
+  border-left-color: #8250df;
+}
+
+.markdown-body .markdown-alert-warning {
+  border-left-color: #9a6700;
+}
+
+.markdown-body .markdown-alert-caution {
+  border-left-color: #d1242f;
+}
+
+.markdown-body .markdown-alert-note .markdown-alert-title {
+  color: #0969da;
+}
+
+.markdown-body .markdown-alert-tip .markdown-alert-title {
+  color: #1a7f37;
+}
+
+.markdown-body .markdown-alert-important .markdown-alert-title {
+  color: #8250df;
+}
+
+.markdown-body .markdown-alert-warning .markdown-alert-title {
+  color: #9a6700;
+}
+
+.markdown-body .markdown-alert-caution .markdown-alert-title {
+  color: #d1242f;
+}
+
+/* Dark mode tweaks. github-markdown-dark.css drives the page palette; tune
+ * alert colors so they read against dark backgrounds. */
+.dark .markdown-body .markdown-alert-note {
+  border-left-color: #4493f8;
+}
+.dark .markdown-body .markdown-alert-tip {
+  border-left-color: #3fb950;
+}
+.dark .markdown-body .markdown-alert-important {
+  border-left-color: #ab7df8;
+}
+.dark .markdown-body .markdown-alert-warning {
+  border-left-color: #d29922;
+}
+.dark .markdown-body .markdown-alert-caution {
+  border-left-color: #f85149;
+}
+.dark .markdown-body .markdown-alert-note .markdown-alert-title {
+  color: #4493f8;
+}
+.dark .markdown-body .markdown-alert-tip .markdown-alert-title {
+  color: #3fb950;
+}
+.dark .markdown-body .markdown-alert-important .markdown-alert-title {
+  color: #ab7df8;
+}
+.dark .markdown-body .markdown-alert-warning .markdown-alert-title {
+  color: #d29922;
+}
+.dark .markdown-body .markdown-alert-caution .markdown-alert-title {
+  color: #f85149;
+}
+
+/*
+ * Code blocks (Shiki output wrapped for the copy button) and Mermaid
+ * diagrams. The wrapper is the single `<div>` we replace each placeholder
+ * with — no Svelte component scaffolding around it, so the resulting tree
+ * matches what GitHub renders for README code blocks.
+ */
+.markdown-body .md-code-block {
+  position: relative;
+  margin-bottom: 1rem;
+}
+
+/*
+ * Strip the github-markdown-css `pre` styling (background, padding, margin,
+ * 85% font size) from the Shiki-rendered `pre`. We need `!important` because
+ * github-markdown-css is injected via `<svelte:head>` after main.css and
+ * therefore wins on equal specificity, and Shiki sets the background via an
+ * inline `style` attribute which can only be defeated with `!important`.
+ */
+.markdown-body .md-code-block pre,
+.markdown-body .md-code-block pre code,
+.markdown-body .md-code-block .md-code-content,
+.markdown-body .md-code-block .md-code-content > pre {
+  background: transparent !important;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.markdown-body code,
+.markdown-body pre,
+.markdown-body pre code {
+  /* In GitHub, code block fint size almost same as document's body font size */
+  font-size: 0.9em !important;
+}
+
+/* Copy-to-clipboard button. Always visible (matches current github.com
+ * behavior on rendered READMEs); subtle background that lifts on hover. */
+.markdown-body .md-copy-btn {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border-radius: 0.25rem;
+  border: 1px solid rgba(31, 35, 40, 0.15);
+  background-color: #f6f8fa;
+  color: #57606a;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease-in-out,
+    color 0.15s ease-in-out,
+    border-color 0.15s ease-in-out;
+  z-index: 1;
+}
+
+.markdown-body .md-copy-btn:hover {
+  background-color: #eaeef2;
+  border-color: rgba(31, 35, 40, 0.25);
+  color: #1f2328;
+}
+
+.markdown-body .md-copy-btn:focus-visible {
+  outline: 2px solid #0969da;
+  outline-offset: 2px;
+}
+
+.markdown-body .md-copy-btn.is-copied {
+  color: #1a7f37;
+}
+
+.dark .markdown-body .md-copy-btn {
+  background-color: #21262d;
+  border-color: rgba(240, 246, 252, 0.1);
+  color: #8b949e;
+}
+
+.dark .markdown-body .md-copy-btn:hover {
+  background-color: #30363d;
+  border-color: rgba(240, 246, 252, 0.2);
+  color: #c9d1d9;
+}
+
+.dark .markdown-body .md-copy-btn:focus-visible {
+  outline-color: #4493f8;
+}
+
+.dark .markdown-body .md-copy-btn.is-copied {
+  color: #3fb950;
+}
+
+/* Mermaid diagrams — center horizontally inside the doc panel. */
+.markdown-body .md-mermaid {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 1rem;
+}
+
+.markdown-body .md-mermaid svg {
+  max-width: 100%;
+  height: auto;
+}

--- a/web/src/pages/MarkdownTest.svelte
+++ b/web/src/pages/MarkdownTest.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+  import { onDestroy } from 'svelte';
+  import { emojify } from 'node-emoji';
+
+  import context, { type Theme } from '@/context';
+  import Navbar from '@/components/Navbar.svelte';
+  import Markdown from '@/components/markdown/Markdown.svelte';
+  import { markdownSample } from '@/lib/markdown/sample';
+
+  import lightCssUrl from 'github-markdown-css/github-markdown-light.css?url';
+  import darkCssUrl from 'github-markdown-css/github-markdown-dark.css?url';
+
+  let currentTheme: Theme = 'light';
+  const unsubscribeTheme = context.theme.subscribe(t => {
+    currentTheme = t;
+  });
+
+  $: markdownCssHref = currentTheme === 'dark' ? darkCssUrl : lightCssUrl;
+  const source = emojify(markdownSample);
+
+  onDestroy(() => unsubscribeTheme());
+</script>
+
+<svelte:head>
+  <title>Terralist — Markdown test</title>
+  <link rel="stylesheet" href={markdownCssHref} />
+</svelte:head>
+
+<Navbar />
+
+<main class="mt-36 mx-4 lg:mt-14 lg:mx-10 text-slate-600 dark:text-slate-200">
+  <section class="mt-20 lg:mx-20 flex flex-col gap-4">
+    <header class="flex flex-col gap-2">
+      <h1 class="text-2xl font-bold tracking-tight dark:text-white">
+        Markdown rendering test
+      </h1>
+      <p class="text-sm">
+        Visual fixture for the GFM renderer. Compare against the same source
+        rendered on github.com to spot regressions.
+      </p>
+    </header>
+    <article class="flex flex-col gap-4">
+      <Markdown {source} />
+    </article>
+  </section>
+</main>

--- a/web/src/routes.ts
+++ b/web/src/routes.ts
@@ -120,6 +120,14 @@ const routes = {
       onFailureRedirectTo: '/login'
     })
   }),
+  '/markdown-test': wrap({
+    asyncComponent: async () => import('@/pages/MarkdownTest.svelte'),
+    loadingComponent: Loading,
+    conditions: baseConditions.concat([isAuthenticatedCondition()]),
+    userData: newUserData({
+      onFailureRedirectTo: '/login'
+    })
+  }),
   '*': wrap({
     asyncComponent: async () => import('@/pages/Error404.svelte'),
     loadingComponent: Loading,

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -15,115 +15,230 @@
     "@jridgewell/gen-mapping" "^0.3.5"
     "@jridgewell/trace-mapping" "^0.3.24"
 
+"@esbuild/aix-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz#c7184a326533fcdf1b8ee0733e21c713b975575f"
+  integrity sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==
+
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
   integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
+
+"@esbuild/android-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz#09d9b4357780da9ea3a7dfb833a1f1ff439b4052"
+  integrity sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==
 
 "@esbuild/android-arm@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
   integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
 
+"@esbuild/android-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.21.5.tgz#9b04384fb771926dfa6d7ad04324ecb2ab9b2e28"
+  integrity sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==
+
 "@esbuild/android-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
   integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
+
+"@esbuild/android-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.21.5.tgz#29918ec2db754cedcb6c1b04de8cd6547af6461e"
+  integrity sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==
 
 "@esbuild/darwin-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
   integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
 
+"@esbuild/darwin-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz#e495b539660e51690f3928af50a76fb0a6ccff2a"
+  integrity sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==
+
 "@esbuild/darwin-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
   integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
+
+"@esbuild/darwin-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz#c13838fa57372839abdddc91d71542ceea2e1e22"
+  integrity sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==
 
 "@esbuild/freebsd-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
   integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
 
+"@esbuild/freebsd-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz#646b989aa20bf89fd071dd5dbfad69a3542e550e"
+  integrity sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==
+
 "@esbuild/freebsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
   integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
+
+"@esbuild/freebsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz#aa615cfc80af954d3458906e38ca22c18cf5c261"
+  integrity sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==
 
 "@esbuild/linux-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
   integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
 
+"@esbuild/linux-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz#70ac6fa14f5cb7e1f7f887bcffb680ad09922b5b"
+  integrity sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==
+
 "@esbuild/linux-arm@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
   integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
+
+"@esbuild/linux-arm@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz#fc6fd11a8aca56c1f6f3894f2bea0479f8f626b9"
+  integrity sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==
 
 "@esbuild/linux-ia32@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
   integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
 
+"@esbuild/linux-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz#3271f53b3f93e3d093d518d1649d6d68d346ede2"
+  integrity sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==
+
 "@esbuild/linux-loong64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
   integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
+
+"@esbuild/linux-loong64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz#ed62e04238c57026aea831c5a130b73c0f9f26df"
+  integrity sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==
 
 "@esbuild/linux-mips64el@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
   integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
 
+"@esbuild/linux-mips64el@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz#e79b8eb48bf3b106fadec1ac8240fb97b4e64cbe"
+  integrity sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==
+
 "@esbuild/linux-ppc64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
   integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
+
+"@esbuild/linux-ppc64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz#5f2203860a143b9919d383ef7573521fb154c3e4"
+  integrity sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==
 
 "@esbuild/linux-riscv64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
   integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
 
+"@esbuild/linux-riscv64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz#07bcafd99322d5af62f618cb9e6a9b7f4bb825dc"
+  integrity sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==
+
 "@esbuild/linux-s390x@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
   integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
+
+"@esbuild/linux-s390x@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz#b7ccf686751d6a3e44b8627ababc8be3ef62d8de"
+  integrity sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==
 
 "@esbuild/linux-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz"
   integrity sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==
 
+"@esbuild/linux-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz#6d8f0c768e070e64309af8004bb94e68ab2bb3b0"
+  integrity sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==
+
 "@esbuild/netbsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
   integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
+
+"@esbuild/netbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz#bbe430f60d378ecb88decb219c602667387a6047"
+  integrity sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==
 
 "@esbuild/openbsd-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
   integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
 
+"@esbuild/openbsd-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz#99d1cf2937279560d2104821f5ccce220cb2af70"
+  integrity sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==
+
 "@esbuild/sunos-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
   integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
+
+"@esbuild/sunos-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz#08741512c10d529566baba837b4fe052c8f3487b"
+  integrity sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==
 
 "@esbuild/win32-arm64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
   integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
 
+"@esbuild/win32-arm64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz#675b7385398411240735016144ab2e99a60fc75d"
+  integrity sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==
+
 "@esbuild/win32-ia32@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
   integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
 
+"@esbuild/win32-ia32@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz#1bfc3ce98aa6ca9a0969e4d2af72144c59c1193b"
+  integrity sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==
+
 "@esbuild/win32-x64@0.18.20":
   version "0.18.20"
   resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
+
+"@esbuild/win32-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz#acad351d582d157bb145535db2a6ff53dd514b5c"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.6.1", "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
   version "4.9.1"
@@ -316,6 +431,131 @@
   resolved "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz"
   integrity sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==
 
+"@rollup/rollup-android-arm-eabi@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz#a19c645c375158cd5c50a344106f0fa18eb821c4"
+  integrity sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==
+
+"@rollup/rollup-android-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz#1af19aa9d3ad6d00df2681f59cfcb8bf7499576b"
+  integrity sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==
+
+"@rollup/rollup-darwin-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz#3b8463e03ba2a393453fea70e7d907379c27b649"
+  integrity sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==
+
+"@rollup/rollup-darwin-x64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz#28da23d69fe117f5f0ff330a8549e51bd09f1b6a"
+  integrity sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==
+
+"@rollup/rollup-freebsd-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz#94bacac3190f621de1355922b599f3817786044c"
+  integrity sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==
+
+"@rollup/rollup-freebsd-x64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz#8a0094f533b9fda160b5c90ad9e0c78fca341788"
+  integrity sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz#3b7e901a555c7245c87f7440979bee0a1ec882bb"
+  integrity sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==
+
+"@rollup/rollup-linux-arm-musleabihf@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz#ee9a09b72e8ad764cfd6188b32ff1de528ff7ebe"
+  integrity sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==
+
+"@rollup/rollup-linux-arm64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz#ba483f4aca9be141171d086dbd01ada6ab03b58d"
+  integrity sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==
+
+"@rollup/rollup-linux-arm64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz#17b595b790e6df68e91c5d02526fc832a985ce4f"
+  integrity sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==
+
+"@rollup/rollup-linux-loong64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz#551718714075a2bfb36a2813c466e3a0e9d56abf"
+  integrity sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==
+
+"@rollup/rollup-linux-loong64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz#ba156ed1243447a3d710972001d5dcfe3827ff3d"
+  integrity sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==
+
+"@rollup/rollup-linux-ppc64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz#6a957a709b86ac62ef68e597ac03dbd4336782b1"
+  integrity sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==
+
+"@rollup/rollup-linux-ppc64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz#ca4176b4ad53f3edee3b4bfa6f9ef48ff38f167b"
+  integrity sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==
+
+"@rollup/rollup-linux-riscv64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz#4e6b08f72ebeafdb41f3ec433bd228ba8573473b"
+  integrity sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==
+
+"@rollup/rollup-linux-riscv64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz#a0b8b8580c7680c8086cb3226527e5472253b895"
+  integrity sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==
+
+"@rollup/rollup-linux-s390x-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz#79fe15b92ce0bae2b609cf26dd158cd3e2b73634"
+  integrity sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==
+
+"@rollup/rollup-linux-x64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz#6aa8302fa45fd3cbbc510ccd223c9c37bf67e53f"
+  integrity sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==
+
+"@rollup/rollup-linux-x64-musl@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz#0c1a5e9799f80c47a66f2c3a5f1a280f38356047"
+  integrity sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==
+
+"@rollup/rollup-openbsd-x64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz#5f07c863e74fd428794f1dc5749f321b661d1f17"
+  integrity sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==
+
+"@rollup/rollup-openharmony-arm64@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz#8e0d71324be0f423428b12b25a2eb8ea8e0a7833"
+  integrity sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==
+
+"@rollup/rollup-win32-arm64-msvc@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz#a553fdf90a785ace6d7501eed6241c468b088999"
+  integrity sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==
+
+"@rollup/rollup-win32-ia32-msvc@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz#0fb04f0a88027fbfd323e25a446debce4773868c"
+  integrity sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==
+
+"@rollup/rollup-win32-x64-gnu@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz#aaa9e36dbdc0f0e397e5966dcce1b4285354ede2"
+  integrity sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==
+
+"@rollup/rollup-win32-x64-msvc@4.60.2":
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz#3418dcf1388f2abd6b0ccc08fe1ef205ae76d696"
+  integrity sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==
+
 "@sinclair/typebox@^0.27.8":
   version "0.27.10"
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz"
@@ -363,7 +603,17 @@
   resolved "https://registry.npmjs.org/@tsconfig/svelte/-/svelte-5.0.8.tgz"
   integrity sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ==
 
-"@types/estree@^1.0.0", "@types/estree@^1.0.1", "@types/estree@^1.0.6":
+"@types/chai-subset@^1.3.3":
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/@types/chai-subset/-/chai-subset-1.3.6.tgz#fc50f637ebd038ed58700f826d7bab2caa8a8d7e"
+  integrity sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==
+
+"@types/chai@^4.3.5":
+  version "4.3.20"
+  resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.3.20.tgz#cb291577ed342ca92600430841a00329ba05cecc"
+  integrity sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==
+
+"@types/estree@1.0.8", "@types/estree@^1.0.0", "@types/estree@^1.0.1", "@types/estree@^1.0.6":
   version "1.0.8"
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
@@ -372,6 +622,13 @@
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
+"@types/node@*":
+  version "25.6.0"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-25.6.0.tgz#4e09bad9b469871f2d0f68140198cbd714f4edca"
+  integrity sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==
+  dependencies:
+    undici-types "~7.19.0"
 
 "@types/node@^24.10.0":
   version "24.12.2"
@@ -537,17 +794,67 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@vitest/expect@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/@vitest/expect/-/expect-0.34.6.tgz#608a7b7a9aa3de0919db99b4cc087340a03ea77e"
+  integrity sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==
+  dependencies:
+    "@vitest/spy" "0.34.6"
+    "@vitest/utils" "0.34.6"
+    chai "^4.3.10"
+
+"@vitest/runner@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/@vitest/runner/-/runner-0.34.6.tgz#6f43ca241fc96b2edf230db58bcde5b974b8dcaf"
+  integrity sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==
+  dependencies:
+    "@vitest/utils" "0.34.6"
+    p-limit "^4.0.0"
+    pathe "^1.1.1"
+
+"@vitest/snapshot@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/@vitest/snapshot/-/snapshot-0.34.6.tgz#b4528cf683b60a3e8071cacbcb97d18b9d5e1d8b"
+  integrity sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==
+  dependencies:
+    magic-string "^0.30.1"
+    pathe "^1.1.1"
+    pretty-format "^29.5.0"
+
+"@vitest/spy@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/@vitest/spy/-/spy-0.34.6.tgz#b5e8642a84aad12896c915bce9b3cc8cdaf821df"
+  integrity sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==
+  dependencies:
+    tinyspy "^2.1.1"
+
+"@vitest/utils@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/@vitest/utils/-/utils-0.34.6.tgz#38a0a7eedddb8e7291af09a2409cb8a189516968"
+  integrity sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==
+  dependencies:
+    diff-sequences "^29.4.3"
+    loupe "^2.3.6"
+    pretty-format "^29.5.0"
+
 acorn-jsx@^5.3.2:
   version "5.3.2"
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.2.0:
+  version "8.3.5"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
+  integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
+  dependencies:
+    acorn "^8.11.0"
 
 acorn@^8.10.0, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
 
-acorn@^8.15.0:
+acorn@^8.11.0, acorn@^8.15.0, acorn@^8.16.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -621,6 +928,11 @@ array-union@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -712,6 +1024,11 @@ browserslist@^4.28.2:
     node-releases "^2.0.36"
     update-browserslist-db "^1.2.3"
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-6.7.14.tgz#804e1e6f506ee363cb0e3ccbb09cad5dd9870959"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
@@ -734,6 +1051,19 @@ caniuse-lite@^1.0.30001782, caniuse-lite@^1.0.30001787:
   version "1.0.30001788"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz#31e97d1bfec332b3f2d7eea7781460c97629b3bf"
   integrity sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==
+
+chai@^4.3.10:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chai/-/chai-4.5.0.tgz#707e49923afdd9b13a8b0b47d33d732d13812fd8"
+  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.3"
+    deep-eql "^4.1.3"
+    get-func-name "^2.0.2"
+    loupe "^2.3.6"
+    pathval "^1.1.1"
+    type-detect "^4.1.0"
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -758,6 +1088,13 @@ char-regex@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz"
   integrity sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+
+check-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/check-error/-/check-error-1.0.3.tgz#a6502e4312a7ee969f646e83bb3ddd56281bd694"
+  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
+  dependencies:
+    get-func-name "^2.0.2"
 
 chokidar@^3.6.0:
   version "3.6.0"
@@ -826,6 +1163,11 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+confbox@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.yarnpkg.com/confbox/-/confbox-0.1.8.tgz#820d73d3b3c82d9bd910652c5d4d599ef8ff8b06"
+  integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
+
 cross-spawn@^7.0.2, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
@@ -855,6 +1197,13 @@ debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.3:
   dependencies:
     ms "^2.1.3"
 
+deep-eql@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.yarnpkg.com/deep-eql/-/deep-eql-4.1.4.tgz#d0d3912865911bb8fac5afb4e3acfa6a28dc72b7"
+  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
+  dependencies:
+    type-detect "^4.0.0"
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
@@ -874,6 +1223,11 @@ didyoumean@^1.2.2:
   version "1.2.2"
   resolved "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz"
   integrity sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==
+
+diff-sequences@^29.4.3:
+  version "29.6.3"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-29.6.3.tgz#4deaf894d11407c51efc8418012f9e70b84ea921"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -967,6 +1321,35 @@ esbuild@^0.18.10:
     "@esbuild/win32-arm64" "0.18.20"
     "@esbuild/win32-ia32" "0.18.20"
     "@esbuild/win32-x64" "0.18.20"
+
+esbuild@^0.21.3:
+  version "0.21.5"
+  resolved "https://registry.yarnpkg.com/esbuild/-/esbuild-0.21.5.tgz#9ca301b120922959b766360d8ac830da0d02997d"
+  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.21.5"
+    "@esbuild/android-arm" "0.21.5"
+    "@esbuild/android-arm64" "0.21.5"
+    "@esbuild/android-x64" "0.21.5"
+    "@esbuild/darwin-arm64" "0.21.5"
+    "@esbuild/darwin-x64" "0.21.5"
+    "@esbuild/freebsd-arm64" "0.21.5"
+    "@esbuild/freebsd-x64" "0.21.5"
+    "@esbuild/linux-arm" "0.21.5"
+    "@esbuild/linux-arm64" "0.21.5"
+    "@esbuild/linux-ia32" "0.21.5"
+    "@esbuild/linux-loong64" "0.21.5"
+    "@esbuild/linux-mips64el" "0.21.5"
+    "@esbuild/linux-ppc64" "0.21.5"
+    "@esbuild/linux-riscv64" "0.21.5"
+    "@esbuild/linux-s390x" "0.21.5"
+    "@esbuild/linux-x64" "0.21.5"
+    "@esbuild/netbsd-x64" "0.21.5"
+    "@esbuild/openbsd-x64" "0.21.5"
+    "@esbuild/sunos-x64" "0.21.5"
+    "@esbuild/win32-arm64" "0.21.5"
+    "@esbuild/win32-ia32" "0.21.5"
+    "@esbuild/win32-x64" "0.21.5"
 
 escalade@^3.2.0:
   version "3.2.0"
@@ -1296,7 +1679,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
-fsevents@~2.3.2:
+fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
@@ -1305,6 +1688,11 @@ function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-func-name@^2.0.1, get-func-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
+  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
 
 get-intrinsic@^1.2.6:
   version "1.3.0"
@@ -1592,6 +1980,11 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
+local-pkg@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.3.tgz#0ff361ab3ae7f1c19113d9bb97b98b905dbc4963"
+  integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
+
 locate-character@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz"
@@ -1627,7 +2020,14 @@ loglevel@^1.4.1:
   resolved "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz"
   integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
-magic-string@^0.30.3, magic-string@^0.30.4:
+loupe@^2.3.6:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/loupe/-/loupe-2.3.7.tgz#6e69b7d4db7d3ab436328013d37d1c8c3540c697"
+  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
+  dependencies:
+    get-func-name "^2.0.1"
+
+magic-string@^0.30.1, magic-string@^0.30.3, magic-string@^0.30.4:
   version "0.30.21"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz"
   integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
@@ -1719,6 +2119,16 @@ minimatch@^3.1.5:
   dependencies:
     brace-expansion "^1.1.7"
 
+mlly@^1.4.0, mlly@^1.7.4:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/mlly/-/mlly-1.8.2.tgz#e7f7919a82d13b174405613117249a3f449d78bb"
+  integrity sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==
+  dependencies:
+    acorn "^8.16.0"
+    pathe "^2.0.3"
+    pkg-types "^1.3.1"
+    ufo "^1.6.3"
+
 mri@^1.1.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
@@ -1804,6 +2214,13 @@ p-limit@^3.0.2:
   dependencies:
     yocto-queue "^0.1.0"
 
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-4.0.0.tgz#914af6544ed32bfa54670b061cafcbd04984b644"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
 p-locate@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
@@ -1843,6 +2260,21 @@ path-type@^4.0.0:
   resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
   integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
 
+pathe@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-1.1.2.tgz#6c4cb47a945692e48a1ddd6e4094d170516437ec"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathe@^2.0.1, pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/pathe/-/pathe-2.0.3.tgz#3ecbec55421685b70a9da872b2cff3e1cbed1716"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 periscopic@^3.1.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz"
@@ -1876,6 +2308,15 @@ pirates@^4.0.1:
   version "4.0.7"
   resolved "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz"
   integrity sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==
+
+pkg-types@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/pkg-types/-/pkg-types-1.3.1.tgz#bd7cc70881192777eef5326c19deb46e890917df"
+  integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
+  dependencies:
+    confbox "^0.1.8"
+    mlly "^1.7.4"
+    pathe "^2.0.1"
 
 postcss-import@^15.1.0:
   version "15.1.0"
@@ -1955,6 +2396,15 @@ postcss@^8.4.27, postcss@^8.4.47, postcss@^8.4.49, postcss@^8.5.6:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
+postcss@^8.4.43:
+  version "8.5.12"
+  resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.12.tgz#cd0c0f667f7cb0521e2313234ea6e707a9ec1ddb"
+  integrity sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
 prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
@@ -1995,7 +2445,7 @@ prettier@^3.5.3, prettier@^3.6.2:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.8.3.tgz#560f2de55bf01b4c0503bc629d5df99b9a1d09b0"
   integrity sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==
 
-pretty-format@^29.7.0:
+pretty-format@^29.5.0, pretty-format@^29.7.0:
   version "29.7.0"
   resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz"
   integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
@@ -2086,6 +2536,40 @@ rollup@^3.27.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
+rollup@^4.20.0:
+  version "4.60.2"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-4.60.2.tgz#ac23fe4bd530304cef9fa61e639d7098b6762cf4"
+  integrity sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.60.2"
+    "@rollup/rollup-android-arm64" "4.60.2"
+    "@rollup/rollup-darwin-arm64" "4.60.2"
+    "@rollup/rollup-darwin-x64" "4.60.2"
+    "@rollup/rollup-freebsd-arm64" "4.60.2"
+    "@rollup/rollup-freebsd-x64" "4.60.2"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.60.2"
+    "@rollup/rollup-linux-arm-musleabihf" "4.60.2"
+    "@rollup/rollup-linux-arm64-gnu" "4.60.2"
+    "@rollup/rollup-linux-arm64-musl" "4.60.2"
+    "@rollup/rollup-linux-loong64-gnu" "4.60.2"
+    "@rollup/rollup-linux-loong64-musl" "4.60.2"
+    "@rollup/rollup-linux-ppc64-gnu" "4.60.2"
+    "@rollup/rollup-linux-ppc64-musl" "4.60.2"
+    "@rollup/rollup-linux-riscv64-gnu" "4.60.2"
+    "@rollup/rollup-linux-riscv64-musl" "4.60.2"
+    "@rollup/rollup-linux-s390x-gnu" "4.60.2"
+    "@rollup/rollup-linux-x64-gnu" "4.60.2"
+    "@rollup/rollup-linux-x64-musl" "4.60.2"
+    "@rollup/rollup-openbsd-x64" "4.60.2"
+    "@rollup/rollup-openharmony-arm64" "4.60.2"
+    "@rollup/rollup-win32-arm64-msvc" "4.60.2"
+    "@rollup/rollup-win32-ia32-msvc" "4.60.2"
+    "@rollup/rollup-win32-x64-gnu" "4.60.2"
+    "@rollup/rollup-win32-x64-msvc" "4.60.2"
+    fsevents "~2.3.2"
+
 run-parallel@^1.1.9:
   version "1.2.0"
   resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
@@ -2122,6 +2606,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
 skin-tone@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz"
@@ -2138,6 +2627,16 @@ source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.3.3:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/std-env/-/std-env-3.10.0.tgz#d810b27e3a073047b2b5e40034881f5ea6f9c83b"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 strip-ansi@^3.0.0:
   version "3.0.1"
@@ -2157,6 +2656,13 @@ strip-json-comments@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
   integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-literal@^1.0.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/strip-literal/-/strip-literal-1.3.0.tgz#db3942c2ec1699e6836ad230090b84bb458e3a07"
+  integrity sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==
+  dependencies:
+    acorn "^8.10.0"
 
 sucrase@^3.35.0:
   version "3.35.1"
@@ -2310,6 +2816,11 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
+tinybench@^2.5.0:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.9.0.tgz#103c9f8ba6d7237a47ab6dd1dcff77251863426b"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
 tinyglobby@^0.2.11:
   version "0.2.15"
   resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz"
@@ -2325,6 +2836,16 @@ tinyglobby@^0.2.15:
   dependencies:
     fdir "^6.5.0"
     picomatch "^4.0.4"
+
+tinypool@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.7.0.tgz#88053cc99b4a594382af23190c609d93fddf8021"
+  integrity sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==
+
+tinyspy@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/tinyspy/-/tinyspy-2.2.1.tgz#117b2342f1f38a0dbdcc73a50a454883adf861d1"
+  integrity sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -2360,6 +2881,11 @@ type-check@^0.4.0, type-check@~0.4.0:
   dependencies:
     prelude-ls "^1.2.1"
 
+type-detect@^4.0.0, type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.1.0.tgz#deb2453e8f08dcae7ae98c626b13dddb0155906c"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
+
 type-fest@^0.20.2:
   version "0.20.2"
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
@@ -2380,10 +2906,20 @@ typescript@^5.8.2:
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
+ufo@^1.6.3:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/ufo/-/ufo-1.6.4.tgz#7a8fb875fcc6382d2c7d0b3692738b0500a92467"
+  integrity sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==
+
 undici-types@~7.16.0:
   version "7.16.0"
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
+
+undici-types@~7.19.0:
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.19.2.tgz#1b67fc26d0f157a0cba3a58a5b5c1e2276b8ba2a"
+  integrity sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==
 
 unicode-emoji-modifier-base@^1.0.0:
   version "1.0.0"
@@ -2415,6 +2951,29 @@ uuid@^13.0.0:
   resolved "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz"
   integrity sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==
 
+vite-node@0.34.6:
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/vite-node/-/vite-node-0.34.6.tgz#34d19795de1498562bf21541a58edcd106328a17"
+  integrity sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    mlly "^1.4.0"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    vite "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+
+"vite@^3.0.0 || ^4.0.0 || ^5.0.0-0", "vite@^3.1.0 || ^4.0.0 || ^5.0.0-0":
+  version "5.4.21"
+  resolved "https://registry.yarnpkg.com/vite/-/vite-5.4.21.tgz#84a4f7c5d860b071676d39ba513c0d598fdc7027"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
 vite@^4.0.0:
   version "4.5.14"
   resolved "https://registry.npmjs.org/vite/-/vite-4.5.14.tgz"
@@ -2430,6 +2989,36 @@ vitefu@^0.2.4:
   version "0.2.5"
   resolved "https://registry.npmjs.org/vitefu/-/vitefu-0.2.5.tgz"
   integrity sha512-SgHtMLoqaeeGnd2evZ849ZbACbnwQCIwRH57t18FxcXoZop0uQu0uzlIhJBlF/eWVzuce0sHeqPcDo+evVcg8Q==
+
+vitest@^0.34.6:
+  version "0.34.6"
+  resolved "https://registry.yarnpkg.com/vitest/-/vitest-0.34.6.tgz#44880feeeef493c04b7f795ed268f24a543250d7"
+  integrity sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==
+  dependencies:
+    "@types/chai" "^4.3.5"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    "@vitest/expect" "0.34.6"
+    "@vitest/runner" "0.34.6"
+    "@vitest/snapshot" "0.34.6"
+    "@vitest/spy" "0.34.6"
+    "@vitest/utils" "0.34.6"
+    acorn "^8.9.0"
+    acorn-walk "^8.2.0"
+    cac "^6.7.14"
+    chai "^4.3.10"
+    debug "^4.3.4"
+    local-pkg "^0.4.3"
+    magic-string "^0.30.1"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    std-env "^3.3.3"
+    strip-literal "^1.0.1"
+    tinybench "^2.5.0"
+    tinypool "^0.7.0"
+    vite "^3.1.0 || ^4.0.0 || ^5.0.0-0"
+    vite-node "0.34.6"
+    why-is-node-running "^2.2.2"
 
 vue-eslint-parser@^9.4.3:
   version "9.4.3"
@@ -2451,6 +3040,14 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+why-is-node-running@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/why-is-node-running/-/why-is-node-running-2.3.0.tgz#a3f69a97107f494b3cdc3bdddd883a7d65cebf04"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
+
 word-wrap@^1.2.5:
   version "1.2.5"
   resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
@@ -2470,3 +3067,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-1.2.2.tgz#3e09c95d3f1aa89a58c114c99223edf639152c00"
+  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==

--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -17,77 +17,77 @@
 
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
+  resolved "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz#984b4f9c8d0377443cc2dfcef266d02244593622"
   integrity sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==
 
 "@esbuild/android-arm@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
+  resolved "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz#fedb265bc3a589c84cc11f810804f234947c3682"
   integrity sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==
 
 "@esbuild/android-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
+  resolved "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz#35cf419c4cfc8babe8893d296cd990e9e9f756f2"
   integrity sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==
 
 "@esbuild/darwin-arm64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz#08172cbeccf95fbc383399a7f39cfbddaeb0d7c1"
   integrity sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==
 
 "@esbuild/darwin-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz#d70d5790d8bf475556b67d0f8b7c5bdff053d85d"
   integrity sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==
 
 "@esbuild/freebsd-arm64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
+  resolved "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz#98755cd12707f93f210e2494d6a4b51b96977f54"
   integrity sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==
 
 "@esbuild/freebsd-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
+  resolved "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz#c1eb2bff03915f87c29cece4c1a7fa1f423b066e"
   integrity sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==
 
 "@esbuild/linux-arm64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
+  resolved "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz#bad4238bd8f4fc25b5a021280c770ab5fc3a02a0"
   integrity sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==
 
 "@esbuild/linux-arm@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
+  resolved "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz#3e617c61f33508a27150ee417543c8ab5acc73b0"
   integrity sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==
 
 "@esbuild/linux-ia32@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
+  resolved "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz#699391cccba9aee6019b7f9892eb99219f1570a7"
   integrity sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==
 
 "@esbuild/linux-loong64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
+  resolved "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz#e6fccb7aac178dd2ffb9860465ac89d7f23b977d"
   integrity sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==
 
 "@esbuild/linux-mips64el@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
+  resolved "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz#eeff3a937de9c2310de30622a957ad1bd9183231"
   integrity sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==
 
 "@esbuild/linux-ppc64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
+  resolved "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz#2f7156bde20b01527993e6881435ad79ba9599fb"
   integrity sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==
 
 "@esbuild/linux-riscv64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
+  resolved "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz#6628389f210123d8b4743045af8caa7d4ddfc7a6"
   integrity sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==
 
 "@esbuild/linux-s390x@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
+  resolved "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz#255e81fb289b101026131858ab99fba63dcf0071"
   integrity sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==
 
 "@esbuild/linux-x64@0.18.20":
@@ -97,32 +97,32 @@
 
 "@esbuild/netbsd-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
+  resolved "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz#30e8cd8a3dded63975e2df2438ca109601ebe0d1"
   integrity sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==
 
 "@esbuild/openbsd-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
+  resolved "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz#7812af31b205055874c8082ea9cf9ab0da6217ae"
   integrity sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==
 
 "@esbuild/sunos-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
+  resolved "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz#d5c275c3b4e73c9b0ecd38d1ca62c020f887ab9d"
   integrity sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==
 
 "@esbuild/win32-arm64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
+  resolved "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz#73bc7f5a9f8a77805f357fab97f290d0e4820ac9"
   integrity sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==
 
 "@esbuild/win32-ia32@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
+  resolved "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz#ec93cbf0ef1085cc12e71e0d661d20569ff42102"
   integrity sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==
 
 "@esbuild/win32-x64@0.18.20":
   version "0.18.20"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz#786c5f41f043b07afb1af37683d7c33668858f6d"
   integrity sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==
 
 "@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.6.1", "@eslint-community/eslint-utils@^4.8.0", "@eslint-community/eslint-utils@^4.9.1":
@@ -274,7 +274,7 @@
 
 "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
+  resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
 
 "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.4.15", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
@@ -328,7 +328,7 @@
 
 "@stylistic/eslint-plugin@^5.5.0":
   version "5.10.0"
-  resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz#471bbd9f7a27ceaac4a217e7f5b3890855e5640c"
+  resolved "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.10.0.tgz#471bbd9f7a27ceaac4a217e7f5b3890855e5640c"
   integrity sha512-nPK52ZHvot8Ju/0A4ucSX1dcPV2/1clx0kLcH5wDmrE4naKso7TUC/voUyU1O9OTKTrR6MYip6LP0ogEMQ9jPQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.9.1"
@@ -373,14 +373,9 @@
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/marked@^5.0.1":
-  version "5.0.2"
-  resolved "https://registry.npmjs.org/@types/marked/-/marked-5.0.2.tgz"
-  integrity sha512-OucS4KMHhFzhz27KxmWg7J+kIYqyqoW5kdIEI319hqARQQUTqhao3M/F+uFnDXD0Rg72iDDZxZNxq5gvctmLlg==
-
 "@types/node@^24.10.0":
   version "24.12.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
+  resolved "https://registry.npmjs.org/@types/node/-/node-24.12.2.tgz#353cb161dbf1785ea25e8829ba7ec574c5c629ac"
   integrity sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==
   dependencies:
     undici-types "~7.16.0"
@@ -479,7 +474,7 @@
 
 "@typescript-eslint/types@^8.56.0":
   version "8.58.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.58.0.tgz#e94ae7abdc1c6530e71183c1007b61fa93112a5a"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz#e94ae7abdc1c6530e71183c1007b61fa93112a5a"
   integrity sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==
 
 "@typescript-eslint/typescript-estree@6.21.0":
@@ -544,7 +539,7 @@
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^8.10.0, acorn@^8.9.0:
@@ -554,7 +549,7 @@ acorn@^8.10.0, acorn@^8.9.0:
 
 acorn@^8.15.0:
   version "8.16.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
 
 ajv@^6.12.4, ajv@^6.14.0:
@@ -629,7 +624,7 @@ array-union@^2.1.0:
 
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 autoprefixer@^10.4.21:
@@ -645,7 +640,7 @@ autoprefixer@^10.4.21:
 
 axios@^1.11.0:
   version "1.15.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz#0fcee91ef03d386514474904b27863b2c683bf4f"
   integrity sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==
   dependencies:
     follow-redirects "^1.15.11"
@@ -719,7 +714,7 @@ browserslist@^4.28.2:
 
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
   integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
   dependencies:
     es-errors "^1.3.0"
@@ -781,7 +776,7 @@ chokidar@^3.6.0:
 
 chokidar@^4.0.1:
   version "4.0.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
+  resolved "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz#7be37a4c03c9aee1ecfe862a4a23b2c70c205d30"
   integrity sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==
   dependencies:
     readdirp "^4.0.1"
@@ -811,7 +806,7 @@ color-name@~1.1.4:
 
 combined-stream@^1.0.8:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
@@ -850,7 +845,7 @@ css-tree@^2.3.1:
 
 cssesc@^3.0.0:
   version "3.0.0"
-  resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
+  resolved "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
 debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.3:
@@ -872,7 +867,7 @@ deepmerge@^4.3.1:
 
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
 
 didyoumean@^1.2.2:
@@ -901,7 +896,7 @@ doctrine@^3.0.0:
 
 dunder-proto@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
   integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
   dependencies:
     call-bind-apply-helpers "^1.0.1"
@@ -920,24 +915,24 @@ emojilib@^2.4.0:
 
 es-define-property@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  resolved "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
 
 es-errors@^1.3.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  resolved "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  resolved "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
 
 es-set-tostringtag@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  resolved "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
   integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
   dependencies:
     es-errors "^1.3.0"
@@ -1003,7 +998,7 @@ eslint-plugin-prettier@^5.2.3:
 
 eslint-plugin-svelte@^3.1.0:
   version "3.17.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-svelte/-/eslint-plugin-svelte-3.17.0.tgz#01826694f056b08e0d26680fe93ca1825d4ffcc4"
+  resolved "https://registry.npmjs.org/eslint-plugin-svelte/-/eslint-plugin-svelte-3.17.0.tgz#01826694f056b08e0d26680fe93ca1825d4ffcc4"
   integrity sha512-sF6wgd5FLS2P8CCaOy2HdYYYEcZ6TwL251dLHUkNmtLnWECk1Dwc+j6VeulmmnFxr7Xs0WNtjweOA+bJ0PnaFw==
   dependencies:
     "@eslint-community/eslint-utils" "^4.6.1"
@@ -1035,12 +1030,12 @@ eslint-scope@^8.2.0, eslint-scope@^8.4.0:
 
 eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   version "3.4.3"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 eslint-visitor-keys@^4.0.0, eslint-visitor-keys@^4.2.1:
   version "4.2.1"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz#4cfea60fe7dd0ad8e816e1ed026c1d5251b512c1"
   integrity sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==
 
 eslint-visitor-keys@^5.0.0:
@@ -1159,7 +1154,7 @@ esquery@^1.4.0, esquery@^1.4.2, esquery@^1.5.0:
 
 esrecurse@^4.3.0:
   version "4.3.0"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
   integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
     estraverse "^5.2.0"
@@ -1277,12 +1272,12 @@ flatted@^3.2.9:
 
 follow-redirects@^1.15.11:
   version "1.16.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz#28474a159d3b9d11ef62050a14ed60e4df6d61bc"
   integrity sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==
 
 form-data@^4.0.5:
   version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
@@ -1303,17 +1298,17 @@ fs.realpath@^1.0.0:
 
 fsevents@~2.3.2:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
 get-intrinsic@^1.2.6:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
   dependencies:
     call-bind-apply-helpers "^1.0.2"
@@ -1329,7 +1324,7 @@ get-intrinsic@^1.2.6:
 
 get-proto@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  resolved "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
   integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
   dependencies:
     dunder-proto "^1.0.1"
@@ -1339,6 +1334,11 @@ github-markdown-css@^5.8.1:
   version "5.9.0"
   resolved "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.9.0.tgz"
   integrity sha512-tmT5sY+zvg2302XLYEfH2mtkViIM1SWf2nvYoF5N1ZsO0V6B2qZTiw3GOzw4vpjLygK/KG35qRlPFweHqfzz5w==
+
+github-slugger@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/github-slugger/-/github-slugger-2.0.0.tgz#52cf2f9279a21eb6c59dd385b410f0c0adda8f1a"
+  integrity sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==
 
 glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
@@ -1397,7 +1397,7 @@ globby@^11.1.0:
 
 gopd@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
 graphemer@^1.4.0:
@@ -1419,19 +1419,19 @@ has-flag@^4.0.0:
 
 has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
 has-tostringtag@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  resolved "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
   integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
   dependencies:
     has-symbols "^1.0.3"
 
 hasown@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
@@ -1566,7 +1566,7 @@ kleur@^4.1.5:
 
 known-css-properties@^0.37.0:
   version "0.37.0"
-  resolved "https://registry.yarnpkg.com/known-css-properties/-/known-css-properties-0.37.0.tgz#10ebe49b9dbb6638860ff8a002fb65a053f4aec5"
+  resolved "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz#10ebe49b9dbb6638860ff8a002fb65a053f4aec5"
   integrity sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==
 
 levn@^0.4.1:
@@ -1579,7 +1579,7 @@ levn@^0.4.1:
 
 lilconfig@^2.0.5:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
+  resolved "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz#78e23ac89ebb7e1bfbf25b18043de756548e7f52"
   integrity sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==
 
 lilconfig@^3.1.1, lilconfig@^3.1.3:
@@ -1634,14 +1634,31 @@ magic-string@^0.30.3, magic-string@^0.30.4:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
-marked@^5.1.2:
-  version "5.1.2"
-  resolved "https://registry.npmjs.org/marked/-/marked-5.1.2.tgz"
-  integrity sha512-ahRPGXJpjMjwSOlBoTMZAK7ATXkli5qCPxZ21TG44rx1KEo44bii4ekgTDQPNRQ4Kh7JMb9Ub1PVk1NxRSsorg==
+marked-alert@^2:
+  version "2.1.2"
+  resolved "https://registry.npmjs.org/marked-alert/-/marked-alert-2.1.2.tgz#57a3ab3af28b93a70a80cf4682377219a66f1c7d"
+  integrity sha512-EFNRZ08d8L/iEIPLTlQMDjvwIsj03gxWCczYTht6DCiHJIZhMk4NK5gtPY9UqAYb09eV5VGT+jD4lp396E0I+w==
+
+marked-footnote@^1:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/marked-footnote/-/marked-footnote-1.4.0.tgz#b08e6145634fd85e4965863607d4af35c82f19d1"
+  integrity sha512-fZTxAhI1TcLEs5UOjCfYfTHpyKGaWQevbxaGTEA68B51l7i87SctPFtHETYqPkEN0ka5opvy4Dy1l/yXVC+hmg==
+
+marked-gfm-heading-id@^4:
+  version "4.1.4"
+  resolved "https://registry.npmjs.org/marked-gfm-heading-id/-/marked-gfm-heading-id-4.1.4.tgz#9f0ee7bace35ce9c90c58700593d6cdbb4618706"
+  integrity sha512-CspnvVfHSkb/znqdPS4jUR8HtCjq3M/DnrsJCrfLBLvdrgbemmoINKpeWKQYkBiXAoBGejw0cV7xzqrPdup3WA==
+  dependencies:
+    github-slugger "^2.0.0"
+
+marked@^15:
+  version "15.0.12"
+  resolved "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz#30722c7346e12d0a2d0207ab9b0c4f0102d86c4e"
+  integrity sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  resolved "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
 mdn-data@2.0.30:
@@ -1664,12 +1681,12 @@ micromatch@^4.0.8:
 
 mime-db@1.52.0:
   version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12:
   version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
@@ -1704,7 +1721,7 @@ minimatch@^3.1.5:
 
 mri@^1.1.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
+  resolved "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz#6721480fec2a11a4889861115a48b6cbe7cc8f0b"
   integrity sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==
 
 ms@^2.1.3:
@@ -1723,7 +1740,7 @@ mz@^2.7.0:
 
 nanoid@^3.3.11:
   version "3.3.11"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz#4f4f112cefbe303202f2199838128936266d185b"
   integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
 
 natural-compare@^1.4.0:
@@ -1837,7 +1854,7 @@ periscopic@^3.1.0:
 
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
@@ -1847,7 +1864,7 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
 
 picomatch@^4.0.3, picomatch@^4.0.4:
   version "4.0.4"
-  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
+  resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz#fd6f5e00a143086e074dffe4c924b8fb293b0589"
   integrity sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==
 
 pify@^2.3.0:
@@ -1878,7 +1895,7 @@ postcss-js@^4.0.1:
 
 postcss-load-config@^3.1.4:
   version "3.1.4"
-  resolved "https://registry.yarnpkg.com/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
+  resolved "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-3.1.4.tgz#1ab2571faf84bb078877e1d07905eabe9ebda855"
   integrity sha512-6DiM4E7v4coTE4uzA8U//WhtPwyhiim3eyjEMFCnUpzbrkK9wJHgKDT2mR+HbtSrd/NubVaYTOpSpjUl8NQeRg==
   dependencies:
     lilconfig "^2.0.5"
@@ -1900,12 +1917,12 @@ postcss-nested@^6.2.0:
 
 postcss-safe-parser@^7.0.0:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz#36e4f7e608111a0ca940fd9712ce034718c40ec0"
+  resolved "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz#36e4f7e608111a0ca940fd9712ce034718c40ec0"
   integrity sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==
 
 postcss-scss@^4.0.9:
   version "4.0.9"
-  resolved "https://registry.yarnpkg.com/postcss-scss/-/postcss-scss-4.0.9.tgz#a03c773cd4c9623cb04ce142a52afcec74806685"
+  resolved "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.9.tgz#a03c773cd4c9623cb04ce142a52afcec74806685"
   integrity sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==
 
 postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
@@ -1918,7 +1935,7 @@ postcss-selector-parser@^6.1.1, postcss-selector-parser@^6.1.2:
 
 postcss-selector-parser@^7.0.0:
   version "7.1.1"
-  resolved "https://registry.yarnpkg.com/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
+  resolved "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz#e75d2e0d843f620e5df69076166f4e16f891cb9f"
   integrity sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==
   dependencies:
     cssesc "^3.0.0"
@@ -1989,7 +2006,7 @@ pretty-format@^29.7.0:
 
 proxy-from-env@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
   integrity sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==
 
 punycode@^2.1.0:
@@ -2016,7 +2033,7 @@ read-cache@^1.0.0:
 
 readdirp@^4.0.1:
   version "4.1.2"
-  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
+  resolved "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz#eb85801435fbf2a7ee58f19e0921b068fc69948d"
   integrity sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==
 
 readdirp@~3.6.0:
@@ -2078,7 +2095,7 @@ run-parallel@^1.1.9:
 
 sade@^1.7.4:
   version "1.8.1"
-  resolved "https://registry.yarnpkg.com/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
+  resolved "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz#0a78e81d658d394887be57d2a409bf703a3b2701"
   integrity sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==
   dependencies:
     mri "^1.1.0"
@@ -2119,7 +2136,7 @@ slash@^3.0.0:
 
 source-map-js@^1.0.1, source-map-js@^1.2.1:
   version "1.2.1"
-  resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz#1ce5650fddd87abc099eda37dcff024c2667ae46"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 strip-ansi@^3.0.0:
@@ -2173,7 +2190,7 @@ supports-preserve-symlinks-flag@^1.0.0:
 
 svelte-check@^4.1.4:
   version "4.4.6"
-  resolved "https://registry.yarnpkg.com/svelte-check/-/svelte-check-4.4.6.tgz#c890a102e94ef31b44bea26f5f16de14db717a3b"
+  resolved "https://registry.npmjs.org/svelte-check/-/svelte-check-4.4.6.tgz#c890a102e94ef31b44bea26f5f16de14db717a3b"
   integrity sha512-kP1zG81EWaFe9ZyTv4ZXv44Csi6Pkdpb7S3oj6m+K2ec/IcDg/a8LsFsnVLqm2nxtkSwsd5xPj/qFkTBgXHXjg==
   dependencies:
     "@jridgewell/trace-mapping" "^0.3.25"
@@ -2199,14 +2216,6 @@ svelte-hmr@^0.15.3:
   version "0.15.3"
   resolved "https://registry.npmjs.org/svelte-hmr/-/svelte-hmr-0.15.3.tgz"
   integrity sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==
-
-svelte-markdown@^0.4.1:
-  version "0.4.1"
-  resolved "https://registry.npmjs.org/svelte-markdown/-/svelte-markdown-0.4.1.tgz"
-  integrity sha512-pOlLY6EruKJaWI9my/2bKX8PdTeP5CM0s4VMmwmC2prlOkjAf+AOmTM4wW/l19Y6WZ87YmP8+ZCJCCwBChWjYw==
-  dependencies:
-    "@types/marked" "^5.0.1"
-    marked "^5.1.2"
 
 svelte-spa-router@^4.0.1:
   version "4.0.2"
@@ -2373,7 +2382,7 @@ typescript@^5.8.2:
 
 undici-types@~7.16.0:
   version "7.16.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
+  resolved "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz#ffccdff36aea4884cbfce9a750a0580224f58a46"
   integrity sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==
 
 unicode-emoji-modifier-base@^1.0.0:
@@ -2398,7 +2407,7 @@ uri-js@^4.2.2:
 
 util-deprecate@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
+  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 uuid@^13.0.0:
@@ -2454,7 +2463,7 @@ wrappy@1:
 
 yaml@^1.10.2:
   version "1.10.3"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
+  resolved "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz#76e407ed95c42684fb8e14641e5de62fe65bbcb3"
   integrity sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==
 
 yocto-queue@^0.1.0:


### PR DESCRIPTION
## Markdown rendering

- Replaces **svelte-markdown** with a **marked**-based pipeline (`marked`, `marked-alert`, `marked-footnote`) plus a small **Slugger** for GitHub-style heading IDs and permalink markup.
- **Security:** URL allowlisting for links, GFM-style disallowed raw HTML post-processing, and code blocks emitted as placeholders then hydrated with **`MarkdownCode`** (Shiki + Mermaid from CDN).
- **`Markdown`** wraps `{@html}` output, mounts Shiki/Mermaid per block, and handles **hash-router** behavior: plain `#…` links no longer replace `#/route`; in-doc targets use a shareable **`?md-anchor=`** form on the hash URL.
- Deep links **retry scroll** until the target exists and **nudge scroll** as layout settles (Shiki/Mermaid). Footnote highlight uses **`.md-anchor-target`** when `:target` does not apply.
- **`Artifact`** readme and submodule docs now use **`Markdown`** (with redundant nested `markdown-body` wrappers removed where appropriate).

## UI / CSS

- **`main.css`** adds GitHub-flavored overrides on top of **github-markdown-css** and Tailwind preflight: list markers, heading anchor affordance, footnotes, alerts (light/dark), code-block copy control, Mermaid centering, and Shiki `pre` overrides so sizing/background match the rest of the doc.

## Dev / ops

- **`Taskfile`:** new **`server:clean`** (`web/dist`, `web/node_modules`, `go clean -cache`).
- **E2E / manual server task:** stop orphan **rustfs/mock-oauth2** containers before run; use **`defer`** for sqlite cleanup, docker stop, and server `pkill` so cleanup runs even when the task is interrupted.
- **`web/.npmrc`** pins the npm registry; **`package.json` / `yarn.lock`** reflect the markdown dependency swap and registry resolution URLs.

## Bugfix

- **`Navbar`:** `z-1` / `z-3` are not in Tailwind’s default z-index scale, so the fixed header had no effective stacking and page content could paint over it. Replaced with **`z-10`** (header) and **`z-30`** (mobile drawer).

## Test / QA aid

- Adds **`/markdown-test`** (authenticated route), **`MarkdownTest.svelte`**, and **`sample.ts`** as a broad GFM fixture for visual regression checks against GitHub.
