### PR TITLE
fix(auth): prefer GitHub login over display name as user identifier

### DIFF
--- a/pkg/auth/github/provider.go
+++ b/pkg/auth/github/provider.go
@@ -167,12 +167,12 @@ func (p *Provider) PerformUserNameRequest(t tokenResponse) (string, error) {
 		return "", err
 	}
 
-	if name, ok := data["name"].(string); ok {
-		return name, nil
-	}
-
 	if login, ok := data["login"].(string); ok {
 		return login, nil
+	}
+
+	if name, ok := data["name"].(string); ok {
+		return name, nil
 	}
 
 	return "", fmt.Errorf("could not get the user or login name")


### PR DESCRIPTION
## Summary

GitHub's `login` field is a stable, unique identifier whereas `name` (display name) is optional, non-unique, and can be changed by the user. The current implementation prefers `name` over `login`, which causes RBAC policy entries to break when a user has a display name set.

This change swaps the check order so `login` is used as the primary identifier with `name` as fallback.