### PR TITLE
fix: reject file:// scheme when fetching modules and providers

### DIFF
--- a/pkg/file/fetch.go
+++ b/pkg/file/fetch.go
@@ -30,7 +30,6 @@ func generateGetters(header http.Header) map[string]getter.Getter {
 	}
 
 	return map[string]getter.Getter{
-		"file":  new(getter.FileGetter),
 		"git":   new(getter.GitGetter),
 		"gcs":   new(getter.GCSGetter),
 		"hg":    new(getter.HgGetter),
@@ -125,6 +124,16 @@ func fetch(name string, url string, checksum string, kind int, header http.Heade
 		return nil, nil, fmt.Errorf("%w: %v", ErrDownloadFailure, err)
 	case <-ctx.Done():
 		wg.Wait()
+
+		// The download goroutine cancels the context as it exits, so reaching
+		// here can also mean the download finished with an error. Surface that
+		// error instead of treating the download as successful.
+		select {
+		case err := <-ech:
+			cleanup()
+			return nil, nil, fmt.Errorf("%w: %v", ErrDownloadFailure, err)
+		default:
+		}
 
 		// If we know the type, just parse it
 		if kind == file || kind == dir {

--- a/pkg/file/fetch_test.go
+++ b/pkg/file/fetch_test.go
@@ -1,27 +1,52 @@
 package file
 
 import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestFetch_CleanupRemovesTempDir(t *testing.T) {
-	// Create a local file to fetch
-	tempFile, err := os.CreateTemp("", "test-fetch-cleanup-*")
+func TestFetch_RejectsFileScheme(t *testing.T) {
+	// Create a local file to read
+	tempFile, err := os.CreateTemp("", "test-fetch-file-scheme-*")
 	if err != nil {
 		t.Fatalf("Failed to create temp file: %v", err)
 	}
 	defer os.Remove(tempFile.Name())
 
-	if _, err := tempFile.WriteString("test content"); err != nil {
+	if _, err := tempFile.WriteString("sensitive content"); err != nil {
 		t.Fatalf("Failed to write temp file: %v", err)
 	}
 	tempFile.Close()
 
+	// Fetching through the file:// scheme must not be allowed
+	_, cleanup, err := fetch("test.txt", "file://"+tempFile.Name(), "", file, nil)
+	if cleanup != nil {
+		cleanup()
+	}
+
+	if err == nil {
+		t.Fatal("Expected fetch to reject the file:// scheme, but it succeeded")
+	}
+
+	if !errors.Is(err, ErrDownloadFailure) {
+		t.Errorf("Expected ErrDownloadFailure, got: %v", err)
+	}
+}
+
+func TestFetch_CleanupRemovesTempDir(t *testing.T) {
+	// Serve a file over HTTP to fetch
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("test content"))
+	}))
+	defer server.Close()
+
 	// Fetch the file
-	result, cleanup, err := fetch("test.txt", "file://"+tempFile.Name(), "", file, nil)
+	result, cleanup, err := fetch("test.txt", server.URL, "", file, nil)
 	if err != nil {
 		t.Fatalf("fetch failed: %v", err)
 	}


### PR DESCRIPTION
This PR changes the module/provider fetcher to reject the `file://` scheme so a tenant cannot read arbitrary files off the Terralist host.

Many thanks to @tonghuaroot for reporting this issue!