### PR TITLE
chore(ci): move all GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -30,13 +30,13 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Set the commit hash
       run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -45,7 +45,7 @@ jobs:
       run: echo "BUILD_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S")" >> $GITHUB_ENV
 
     - name: Login to Packages Container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -84,7 +84,7 @@ jobs:
 
     - name: Build and push
       if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) }}
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         platforms: linux/arm64,linux/amd64

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           python-version: 3.x
 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: ${{ runner.os }}-mkdocs-material
           path: .cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,7 @@ jobs:
         run: touch web/dist/.gitkeep
 
       - name: Release stable
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         if: (!contains(github.ref, '-pre.'))
         with:
           version: v2.4.8
@@ -113,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Release pre-release
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         if: contains(github.ref, '-pre.')
         with:
           version: v2.4.8

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -23,13 +23,13 @@ jobs:
       uses: actions/checkout@v5
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Set the commit hash
       id: commit-hash
@@ -40,14 +40,14 @@ jobs:
       run: echo "BUILD_TIMESTAMP=$(date +"%Y%m%d%H%M%S")" >> $GITHUB_OUTPUT
 
     - name: Login to Packages Container registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: Dockerfile.test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -284,7 +284,10 @@ jobs:
           # Only download the browser if Playwright's expected build is missing,
           # so a normal run never reaches out to the browser CDN.
           cache="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
-          if compgen -G "$cache/chromium_headless_shell-*" > /dev/null; then
+          # POSIX glob check: set -- expands the pattern, leaving it literal
+          # (a non-existent path) when nothing matches.
+          set -- "$cache"/chromium_headless_shell-*
+          if [ -e "$1" ]; then
             echo "Chromium headless shell already present in $cache; skipping install"
           else
             echo "Chromium headless shell not found; installing"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,7 @@ jobs:
   e2e-tests:
     name: E2E Tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
 
     needs: [build-terralist-binary]
 
@@ -267,12 +268,27 @@ jobs:
       - name: Run API E2E Tests
         run: go test -v -count=1 ./e2e/...
 
-      - name: Run Playwright Frontend Tests
+      - name: Install frontend test dependencies
+        working-directory: e2e/frontend
+        run: npm ci
+
+      - name: Install Playwright browser
         working-directory: e2e/frontend
         run: |
-          npm ci
-          npx playwright install --with-deps chromium
-          npx playwright test
+          # The test-base image already ships the browser and OS dependencies.
+          # Only download the browser if Playwright's expected build is missing,
+          # so a normal run never reaches out to the browser CDN.
+          cache="${PLAYWRIGHT_BROWSERS_PATH:-$HOME/.cache/ms-playwright}"
+          if compgen -G "$cache/chromium_headless_shell-*" > /dev/null; then
+            echo "Chromium headless shell already present in $cache; skipping install"
+          else
+            echo "Chromium headless shell not found; installing"
+            npx playwright install chromium
+          fi
+
+      - name: Run Playwright Frontend Tests
+        working-directory: e2e/frontend
+        run: npx playwright test
 
       - name: Stop Terralist server
         if: always()

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,6 +221,11 @@ jobs:
 
       GOCOVERDIR: ${{ format('{0}/coverage/e2e', github.workspace) }}
 
+      # Resolve browsers from the location baked into the test-base image
+      # rather than HOME, which GitHub overrides to /github/home for container
+      # jobs. Keep this in sync with Dockerfile.test.
+      PLAYWRIGHT_BROWSERS_PATH: /ms-playwright
+
     steps:
       - name: Download terralist binary
         uses: actions/download-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
             tools/go.sum
 
       - name: Install task
-        uses: arduino/setup-task@v2.0.0
+        uses: go-task/setup-task@v2
 
       - name: Install dependencies
         run: task --verbose tidy
@@ -248,13 +248,21 @@ jobs:
         run: mkdir -p coverage/e2e
 
       - name: Spin up Terralist server
-        uses: JarvusInnovations/background-action@v1.0.7
-        with:
-          run: terralist server
-          wait-on: |
-            https-get://localhost.direct:${{ env.TERRALIST_PORT }}/check/readyz
-          wait-for: 30s
-          log-output-if: "true"
+        run: |
+          nohup terralist server > /tmp/terralist-server.log 2>&1 &
+          echo "TERRALIST_SERVER_PID=$!" >> "$GITHUB_ENV"
+
+          for i in $(seq 1 30); do
+            if curl -ksf "https://localhost.direct:${TERRALIST_PORT}/check/readyz" >/dev/null; then
+              echo "Terralist is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+
+          echo "::error::Terralist did not become ready within 30s" >&2
+          cat /tmp/terralist-server.log >&2
+          exit 1
 
       - name: Run API E2E Tests
         run: go test -v -count=1 ./e2e/...
@@ -265,6 +273,19 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
           npx playwright test
+
+      - name: Stop Terralist server
+        if: always()
+        run: |
+          if [ -n "$TERRALIST_SERVER_PID" ]; then
+            kill -INT "$TERRALIST_SERVER_PID" 2>/dev/null || true
+            for i in $(seq 1 15); do
+              kill -0 "$TERRALIST_SERVER_PID" 2>/dev/null || break
+              sleep 1
+            done
+          fi
+
+          cat /tmp/terralist-server.log || true
 
       - name: Upload e2e coverage
         if: always() && matrix.database-backend == 'sqlite'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
         run: task --verbose test:unit -- --cover
 
       - name: Upload unit test coverage
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-unit
           path: coverage/unit.txt
@@ -71,7 +71,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Cache Go Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/go-build
@@ -81,7 +81,7 @@ jobs:
             go-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Cache Yarn Packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             web/node_modules
@@ -103,7 +103,7 @@ jobs:
         run: task --verbose build:backend -- --release --cover
 
       - name: Save binary
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: terralist
           path: terralist
@@ -222,7 +222,7 @@ jobs:
 
     steps:
       - name: Download terralist binary
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v7
         with:
           name: terralist
           path: /usr/local/bin/terralist
@@ -268,7 +268,7 @@ jobs:
 
       - name: Upload e2e coverage
         if: always() && matrix.database-backend == 'sqlite'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-e2e
           path: coverage/e2e/
@@ -276,7 +276,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: e2e-reports-${{ matrix.database-backend }}
           path: |
@@ -300,13 +300,13 @@ jobs:
         run: git config --global --add safe.directory /__w/terralist/terralist
 
       - name: Download unit test coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-unit
           path: coverage/
 
       - name: Download e2e coverage
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: coverage-e2e
           path: coverage/e2e/

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -63,7 +63,14 @@ RUN curl -sL https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terra
   && rm terraform.zip \
   && terraform version
 
-# Install Playwright dependencies
-RUN npx playwright install --with-deps chromium
+# Install the Playwright browser pinned to the frontend e2e suite, at a
+# HOME-independent location so the CI job (which runs with HOME=/github/home)
+# finds it instead of re-downloading.
+ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
+COPY e2e/frontend/package.json e2e/frontend/package-lock.json /opt/playwright/
+RUN cd /opt/playwright \
+  && npm ci \
+  && npx playwright install --with-deps chromium \
+  && rm -rf /opt/playwright
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/e2e/frontend/package-lock.json
+++ b/e2e/frontend/package-lock.json
@@ -9,17 +9,17 @@
       "version": "1.0.0",
       "license": "ISC",
       "devDependencies": {
-        "@playwright/test": "^1.58.2"
+        "@playwright/test": "^1.60.0"
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
-      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.59.1"
+        "playwright": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -44,13 +44,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
-      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.59.1"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -63,9 +63,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.59.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
-      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/e2e/frontend/package.json
+++ b/e2e/frontend/package.json
@@ -11,6 +11,6 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "@playwright/test": "^1.58.2"
+    "@playwright/test": "^1.60.0"
   }
 }


### PR DESCRIPTION
This PR moves every GitHub Actions workflow off the Node.js 20 runtime that GitHub is removing from its runners, clearing the deprecation warnings across all workflows.

## What's Changed

- Bumped first-party actions to their Node 24 majors: `actions/cache` v4 to v5, `actions/upload-artifact` v4 to v6, `actions/download-artifact` v4/v5 to v7.
- Bumped the docker and goreleaser actions to their Node 24 majors: `docker/setup-qemu-action`, `docker/setup-buildx-action` and `docker/login-action` v3 to v4, `docker/build-push-action` v6 to v7, and `goreleaser/goreleaser-action` v6 to v7.
- Replaced `arduino/setup-task`, which has no Node 24 release, with the official `go-task/setup-task` action.
- Replaced `JarvusInnovations/background-action`, which is unmaintained with no Node 24 release, with a plain background process and readiness poll for the e2e server, stopping it with SIGINT before the coverage upload so the coverage-instrumented binary flushes its data.
