### PR TITLE
fix: restore module file uploads after dropping the file:// scheme

### DIFF
--- a/e2e/helpers_test.go
+++ b/e2e/helpers_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"os"
 	"testing"
@@ -81,6 +82,30 @@ func doAuthRequest(t *testing.T, method, url string, body any) *http.Response {
 	return doRequest(t, method, url, body, map[string]string{
 		"Authorization": "Bearer x-api-key:" + config.MasterAPIKey,
 	})
+}
+
+// doAuthMultipartUpload uploads content as a multipart form file under the
+// given field, authenticated with the master API key.
+func doAuthMultipartUpload(t *testing.T, url, field, fileName string, content []byte) *http.Response {
+	t.Helper()
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile(field, fileName)
+	require.NoError(t, err)
+	_, err = part.Write(content)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	req, err := http.NewRequest(http.MethodPost, url, &body)
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer x-api-key:"+config.MasterAPIKey)
+
+	resp, err := httpClient().Do(req)
+	require.NoError(t, err)
+
+	return resp
 }
 
 // doUnauthRequest executes an unauthenticated HTTP request.

--- a/e2e/modules_test.go
+++ b/e2e/modules_test.go
@@ -1,12 +1,60 @@
 package e2e
 
 import (
+	"archive/zip"
+	"bytes"
 	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestModuleUploadArchive(t *testing.T) {
+	// Build a minimal module archive in memory.
+	var zipBuf bytes.Buffer
+	zw := zip.NewWriter(&zipBuf)
+	w, err := zw.Create("main.tf")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("locals {\n  test = true\n}\n"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	// Upload it through the multipart file-upload endpoint.
+	resp := doAuthMultipartUpload(
+		t,
+		apiURL("/v1/api/modules/hashicorp/uploaded/local/1.0.0/upload-files"),
+		"module",
+		"module.zip",
+		zipBuf.Bytes(),
+	)
+	body := readJSON(t, resp)
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, body["errors"])
+
+	// Verify the uploaded version is retrievable.
+	resp = doAuthRequest(t, http.MethodGet, apiURL("/v1/modules/hashicorp/uploaded/local/versions"), nil)
+	versionsBody := readJSON(t, resp)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	modules, ok := versionsBody["modules"].([]any)
+	require.True(t, ok)
+	mod, ok := modules[0].(map[string]any)
+	require.True(t, ok)
+	versions, ok := mod["versions"].([]any)
+	require.True(t, ok)
+
+	found := false
+	for _, v := range versions {
+		entry, ok := v.(map[string]any)
+		if ok && entry["version"] == "1.0.0" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "expected uploaded version 1.0.0 to be listed")
+}
 
 func TestModuleListVersions(t *testing.T) {
 	t.Run("unauthenticated", func(t *testing.T) {

--- a/internal/server/controllers/module.go
+++ b/internal/server/controllers/module.go
@@ -3,7 +3,6 @@ package controllers
 import (
 	"fmt"
 	"net/http"
-	"os"
 	"strings"
 
 	"terralist/internal/server/handlers"
@@ -15,7 +14,6 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -155,7 +153,7 @@ func (c *DefaultModuleController) Subscribe(apis ...*gin.RouterGroup) {
 
 			header := file.CreateHeader(body.Headers)
 
-			if err := c.ModuleService.Upload(&dto, body.DownloadUrl, header); err != nil {
+			if err := c.ModuleService.Upload(&dto, file.NewRemoteFile(body.DownloadUrl, header)); err != nil {
 				ctx.JSON(http.StatusConflict, gin.H{
 					"errors": []string{err.Error()},
 				})
@@ -199,57 +197,15 @@ func (c *DefaultModuleController) Subscribe(apis ...*gin.RouterGroup) {
 				return
 			}
 
-			// Create a temp file
-			tempDir, err := os.MkdirTemp("", "terralist-upload-*")
+			// Open the uploaded archive for streaming to the service
+			uploaded, err := moduleFiles[0].Open()
 			if err != nil {
 				ctx.JSON(http.StatusInternalServerError, gin.H{
-					"errors": []string{"cannot create temp directory", err.Error()},
+					"errors": []string{"cannot read the uploaded file", err.Error()},
 				})
 				return
 			}
-			defer os.RemoveAll(tempDir)
-
-			onDiskFile, err := file.SaveToDisk(file.NewFromMultipartFileHeader(moduleFiles[0]), tempDir)
-			if err != nil {
-				ctx.JSON(http.StatusInternalServerError, gin.H{
-					"errors": []string{"cannot allocate a new file", err.Error()},
-				})
-				return
-			}
-
-			defer func() {
-				if err := onDiskFile.Close(); err != nil {
-					log.Error().
-						Err(err).
-						Str("artifact", "module").
-						Str("name", name).
-						Str("provider", provider).
-						Str("version", version).
-						Str("file", onDiskFile.Name()).
-						Str("filepath", onDiskFile.Path()).
-						Msg("could not close the file")
-				}
-
-				if err := onDiskFile.Remove(); err != nil {
-					log.Error().
-						Err(err).
-						Str("artifact", "module").
-						Str("name", name).
-						Str("provider", provider).
-						Str("version", version).
-						Str("file", onDiskFile.Name()).
-						Str("filepath", onDiskFile.Path()).
-						Msg("could not remove module temp disk file")
-				}
-			}()
-
-			// Write form content to the temp file
-			if err := ctx.SaveUploadedFile(moduleFiles[0], onDiskFile.Path()); err != nil {
-				ctx.JSON(http.StatusInternalServerError, gin.H{
-					"errors": []string{"cannot save content to the local disk", err.Error()},
-				})
-				return
-			}
+			defer uploaded.Close()
 
 			dto := module.CreateDTO{
 				AuthorityID: authorityID,
@@ -260,10 +216,9 @@ func (c *DefaultModuleController) Subscribe(apis ...*gin.RouterGroup) {
 				},
 			}
 
-			// Pass-in local-file URI for go-getter
-			uri := fmt.Sprintf("file://%v", onDiskFile.Path())
+			archive := file.NewStreamingFile(moduleFiles[0].Filename, uploaded, moduleFiles[0].Size)
 
-			if err := c.ModuleService.Upload(&dto, uri, nil); err != nil {
+			if err := c.ModuleService.Upload(&dto, archive); err != nil {
 				ctx.JSON(http.StatusConflict, gin.H{
 					"errors": []string{err.Error()},
 				})

--- a/internal/server/services/module.go
+++ b/internal/server/services/module.go
@@ -35,9 +35,11 @@ type ModuleService interface {
 	// downloaded.
 	GetVersionURL(namespace, name, provider, version string) (*string, error)
 
-	// Upload loads a new module version to the system.
-	// If the module does not exist, it will be created.
-	Upload(dto *module.CreateDTO, url string, header http.Header) error
+	// Upload loads a new module version to the system from the given file. A
+	// file.RemoteFile is downloaded from its URL; any other file is treated as
+	// an already uploaded archive. If the module does not exist, it will be
+	// created.
+	Upload(dto *module.CreateDTO, f file.File) error
 
 	// Delete removes a module with all its data from the system.
 	Delete(authorityID uuid.UUID, name string, provider string) error
@@ -145,7 +147,7 @@ func (s *DefaultModuleService) GetSubmoduleDocumentation(namespace, name, provid
 			return "", fmt.Errorf("no fetcher configured to fetch submodule documentation")
 		}
 
-		archive, cleanup, err := s.Fetcher.Fetch(version, v.Location, nil)
+		archive, cleanup, err := s.Fetcher.Fetch(version, file.NewRemoteFile(v.Location, nil))
 		if err != nil {
 			return "", fmt.Errorf("could not fetch module archive for submodule docs: %w", err)
 		}
@@ -296,7 +298,7 @@ func (s *DefaultModuleService) GetVersionURL(namespace, name, provider, version 
 	return location, nil
 }
 
-func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string, header http.Header) error {
+func (s *DefaultModuleService) Upload(d *module.CreateDTO, f file.File) error {
 	// Validate version
 	if semVer := version.Version(d.Version); !semVer.Valid() {
 		return fmt.Errorf("version should respect the semantic versioning standard (semver.org)")
@@ -319,8 +321,9 @@ func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string, header ht
 		}
 	}
 
-	// Download module files
-	archive, cleanup, err := s.Fetcher.Fetch(d.Version, url, header)
+	// Resolve the module files: a remote file is downloaded, an uploaded
+	// archive is decompressed locally.
+	archive, cleanup, err := s.Fetcher.Fetch(d.Version, f)
 	if err != nil {
 		return err
 	}
@@ -453,8 +456,15 @@ func (s *DefaultModuleService) Upload(d *module.CreateDTO, url string, header ht
 				Msg("stored submodule documentation")
 		}
 	} else {
-		// Terralist is using a proxy provider.
-		m.Versions[0].Location = url
+		// Terralist is using the proxy resolver. There is nowhere to store the
+		// files, so this only works when registering a module by URL, which
+		// Terraform then fetches directly. An uploaded archive has no such URL.
+		remote, ok := f.(*file.RemoteFile)
+		if !ok {
+			return fmt.Errorf("a storage resolver is required to upload module archives")
+		}
+
+		m.Versions[0].Location = remote.URL()
 
 		// The documentation of a module can get pretty large and since we have no place to store it
 		// it will end up in the database, increasing the disk size enormously.

--- a/internal/server/services/module_test.go
+++ b/internal/server/services/module_test.go
@@ -192,7 +192,7 @@ func TestGetSubmoduleDocumentation_ProxyResolverWithArchiveRoot(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		mockFetcher.
-			On("Fetch", version, location, mock.Anything).
+			On("Fetch", version, mock.Anything).
 			Return(archive, func() {}, nil)
 
 		doc, err := moduleService.GetSubmoduleDocumentation(namespace, name, provider, version, submodulePath)
@@ -223,7 +223,7 @@ func TestUploadModule(t *testing.T) {
 				dto.Version = "100%-not-sem-ver-valid"
 
 				Convey("When the service is queried", func() {
-					err := moduleService.Upload(&dto, url, nil)
+					err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 					Convey("An error should be returned", func() {
 						So(err, ShouldNotBeNil)
@@ -240,7 +240,7 @@ func TestUploadModule(t *testing.T) {
 						Return(nil, errors.New(""))
 
 					Convey("When the service is queried", func() {
-						err := moduleService.Upload(&dto, url, nil)
+						err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 						Convey("An error should be returned", func() {
 							So(err, ShouldNotBeNil)
@@ -265,7 +265,7 @@ func TestUploadModule(t *testing.T) {
 							}, nil)
 
 						Convey("When the service is queried", func() {
-							err := moduleService.Upload(&dto, url, nil)
+							err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 							Convey("An error should be returned", func() {
 								So(err, ShouldNotBeNil)
@@ -303,11 +303,11 @@ func TestUploadModule(t *testing.T) {
 								expectedErr := errors.New("some reason")
 
 								mockFetcher.
-									On("Fetch", dto.Version, url, mock.AnythingOfType("http.Header")).
+									On("Fetch", dto.Version, mock.Anything).
 									Return(nil, nil, expectedErr)
 
 								Convey("When the service is queried", func() {
-									err := moduleService.Upload(&dto, url, nil)
+									err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 									Convey("The fetcher error should be returned", func() {
 										So(err, ShouldEqual, expectedErr)
@@ -323,7 +323,7 @@ func TestUploadModule(t *testing.T) {
 								So(err, ShouldBeNil)
 
 								mockFetcher.
-									On("Fetch", dto.Version, url, mock.AnythingOfType("http.Header")).
+									On("Fetch", dto.Version, mock.Anything).
 									Return(archive, func() {}, nil)
 
 								Convey("If the resolver is not set", func() {
@@ -334,7 +334,7 @@ func TestUploadModule(t *testing.T) {
 										Return(&module.Module{}, nil)
 
 									Convey("When the service is queried", func() {
-										err := moduleService.Upload(&dto, url, nil)
+										err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 										Convey("No error should be returned", func() {
 											So(err, ShouldBeNil)
@@ -351,7 +351,7 @@ func TestUploadModule(t *testing.T) {
 											Return("", errors.New(""))
 
 										Convey("When the service is queried", func() {
-											err := moduleService.Upload(&dto, url, nil)
+											err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 											Convey("An error should be returned", func() {
 												So(err, ShouldNotBeNil)
@@ -376,7 +376,7 @@ func TestUploadModule(t *testing.T) {
 												Return(&module.Module{}, nil)
 
 											Convey("When the service is queried", func() {
-												err := moduleService.Upload(&dto, url, nil)
+												err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 												Convey("No error should be returned", func() {
 													// If we fail to push the documentation, we ignore and log a warning
@@ -397,7 +397,7 @@ func TestUploadModule(t *testing.T) {
 												Return(&module.Module{}, nil)
 
 											Convey("When the service is queried", func() {
-												err := moduleService.Upload(&dto, url, nil)
+												err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 
 												Convey("No error should be returned", func() {
 													So(err, ShouldBeNil)
@@ -409,6 +409,71 @@ func TestUploadModule(t *testing.T) {
 							})
 						})
 					}
+				})
+			})
+		})
+	})
+}
+
+func TestUploadModuleArchive(t *testing.T) {
+	Convey("Subject: Upload a new module version from an uploaded archive", t, func() {
+		mockModuleRepository := repositories.NewMockModuleRepository(t)
+		mockAuthorityService := NewMockAuthorityService(t)
+		mockResolver := storage.NewMockResolver(t)
+
+		// Use the real fetcher so the uploaded archive is genuinely persisted,
+		// decompressed and re-archived, exercising the upload-files path
+		// without relying on the file:// scheme.
+		moduleService := &DefaultModuleService{
+			ModuleRepository: mockModuleRepository,
+			AuthorityService: mockAuthorityService,
+			Resolver:         mockResolver,
+			Fetcher:          file.NewFetcher(false),
+		}
+
+		Convey("Given a module DTO and an uploaded archive file", func() {
+			dto := module.CreateDTO{}
+			dto.Version = "1.0.0"
+
+			archive, err := file.Archive("module.zip", []file.File{
+				file.NewInMemoryFile("main.tf", []byte("locals {\n  test = true\n}\n")),
+			})
+			So(err, ShouldBeNil)
+
+			mockAuthorityService.
+				On("GetByID", mock.AnythingOfType("uuid.UUID")).
+				Return(&authority.Authority{}, nil)
+			mockModuleRepository.
+				On("Find", mock.AnythingOfType("string"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).
+				Return(nil, errors.New(""))
+
+			Convey("If a resolver is set", func() {
+				location, _ := random.String(16)
+				mockResolver.
+					On("Store", mock.AnythingOfType("*storage.StoreInput")).
+					Return(location, nil)
+				mockModuleRepository.
+					On("Upsert", mock.AnythingOfType("module.Module")).
+					Return(&module.Module{}, nil)
+
+				Convey("When the archive is uploaded", func() {
+					err := moduleService.Upload(&dto, archive)
+
+					Convey("No error should be returned", func() {
+						So(err, ShouldBeNil)
+					})
+				})
+			})
+
+			Convey("If no resolver is set", func() {
+				moduleService.Resolver = nil
+
+				Convey("When the archive is uploaded", func() {
+					err := moduleService.Upload(&dto, archive)
+
+					Convey("An error should be returned, as an uploaded archive cannot be proxied", func() {
+						So(err, ShouldNotBeNil)
+					})
 				})
 			})
 		})
@@ -715,7 +780,7 @@ func TestUploadModuleDocumentation_MultibytePreserved(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		mockFetcher.
-			On("Fetch", dto.Version, url, mock.AnythingOfType("http.Header")).
+			On("Fetch", dto.Version, mock.Anything).
 			Return(arch, func() {}, nil)
 
 		// First store for archive (accept anything but the docs markdown filename)
@@ -752,7 +817,7 @@ func TestUploadModuleDocumentation_MultibytePreserved(t *testing.T) {
 			Return(&module.Module{}, nil)
 
 		Convey("When uploading the module", func() {
-			err := moduleService.Upload(&dto, url, nil)
+			err := moduleService.Upload(&dto, file.NewRemoteFile(url, nil))
 			Convey("Should succeed and preserve content", func() {
 				So(err, ShouldBeNil)
 			})

--- a/pkg/file/fetch.go
+++ b/pkg/file/fetch.go
@@ -209,6 +209,68 @@ func fetch(name string, url string, checksum string, kind int, header http.Heade
 	}
 }
 
+// fetchArchive loads an already-obtained archive from a trusted local source.
+// Unlike fetch, it never goes through go-getter's URL/scheme layer: the bytes
+// are persisted to a temp dir, decompressed with go-getter's decompressors
+// (selected by file extension), and loaded as an archive. It carries no scheme
+// or SSRF surface and is meant for content Terralist already holds, such as a
+// direct file upload.
+func fetchArchive(name string, f File) (File, func(), error) {
+	tempDir, err := os.MkdirTemp("", tempDirPattern)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w: could not create temp dir: %v", ErrSystemFailure, err)
+	}
+
+	cleanup := func() { os.RemoveAll(tempDir) }
+
+	src, err := SaveToDisk(f, tempDir)
+	if err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("%w: could not persist archive: %v", ErrSystemFailure, err)
+	}
+
+	decompressor, ok := matchDecompressor(f.Name())
+	if !ok {
+		// Not a recognized archive; load it as a single file.
+		result, err := readFile(name, src.Path())
+		if err != nil {
+			cleanup()
+			return nil, nil, err
+		}
+
+		return result, cleanup, nil
+	}
+
+	dst := path.Join(tempDir, "extracted")
+	if err := decompressor.Decompress(dst, src.Path(), true, 0); err != nil {
+		cleanup()
+		return nil, nil, fmt.Errorf("%w: %v", ErrDownloadFailure, err)
+	}
+
+	result, err := archiveDir(name, dst)
+	if err != nil {
+		cleanup()
+		return nil, nil, err
+	}
+
+	return result, cleanup, nil
+}
+
+// matchDecompressor selects the go-getter decompressor whose extension is the
+// longest match for the given file name, mirroring go-getter's own detection.
+func matchDecompressor(name string) (getter.Decompressor, bool) {
+	var matched getter.Decompressor
+	matchingLen := 0
+	for ext, dec := range getter.Decompressors {
+		if strings.HasSuffix(name, "."+ext) && len(ext) > matchingLen {
+			matched = dec
+			matchingLen = len(ext)
+		}
+	}
+
+	return matched, matched != nil
+}
+
 // parseResult parses the download result and returns an
 // File.
 func parseResult(name, src string, kind int) (File, error) {

--- a/pkg/file/fetch_test.go
+++ b/pkg/file/fetch_test.go
@@ -1,6 +1,7 @@
 package file
 
 import (
+	"archive/zip"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -9,6 +10,55 @@ import (
 	"strings"
 	"testing"
 )
+
+func TestFetchArchive_LoadsLocalArchive(t *testing.T) {
+	// Build a zip archive on disk, mimicking an uploaded module file.
+	tempDir, err := os.MkdirTemp("", "test-fetch-archive-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tempDir)
+
+	zipPath := filepath.Join(tempDir, "module.zip")
+	zf, err := os.Create(zipPath)
+	if err != nil {
+		t.Fatalf("Failed to create zip: %v", err)
+	}
+	zw := zip.NewWriter(zf)
+	w, err := zw.Create("main.tf")
+	if err != nil {
+		t.Fatalf("Failed to add zip entry: %v", err)
+	}
+	if _, err := w.Write([]byte("# module content")); err != nil {
+		t.Fatalf("Failed to write zip entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("Failed to close zip writer: %v", err)
+	}
+	zf.Close()
+
+	uploaded, err := LoadFromDisk("module.zip", zipPath)
+	if err != nil {
+		t.Fatalf("Failed to load uploaded archive: %v", err)
+	}
+
+	// Loading the archive must not require any URL scheme.
+	result, cleanup, err := fetchArchive("module", uploaded)
+	if err != nil {
+		t.Fatalf("fetchArchive failed: %v", err)
+	}
+	defer cleanup()
+	defer result.Close()
+
+	archiveFile, ok := result.(*ArchiveFile)
+	if !ok {
+		t.Fatalf("Expected *ArchiveFile, got %T", result)
+	}
+
+	if _, found := archiveFile.FS().files["main.tf"]; !found {
+		t.Errorf("Expected archive FS to contain main.tf, got files: %v", archiveFile.FS().files)
+	}
+}
 
 func TestFetch_RejectsFileScheme(t *testing.T) {
 	// Create a local file to read

--- a/pkg/file/fetcher.go
+++ b/pkg/file/fetcher.go
@@ -3,14 +3,15 @@ package file
 import "net/http"
 
 type Fetcher interface {
-	// Fetch downloads a file or a directory from a given URL
-	// and returns it along with a cleanup function.
-	// If the file is a directory, it will be archived.
-	// If the file is an archive, it will be decompressed, and
-	// then compressed back to zip.
-	// The caller must invoke the cleanup function when the file
-	// is no longer needed to remove the temporary directory.
-	Fetch(name string, url string, header http.Header) (File, func(), error)
+	// Fetch resolves a File into a module archive along with a cleanup
+	// function. A RemoteFile is downloaded from its URL (through go-getter,
+	// with no local-file scheme); any other File is treated as an already
+	// uploaded archive and decompressed locally without reaching the network.
+	// If the resolved source is a directory it is archived; if it is an
+	// archive it is decompressed and then compressed back to zip. The caller
+	// must invoke the cleanup function when the file is no longer needed to
+	// remove the temporary directory.
+	Fetch(name string, f File) (File, func(), error)
 
 	// FetchFile downloads a file from a given URL and returns it
 	// along with a cleanup function.
@@ -49,8 +50,12 @@ func NewFetcher(allowPrivateAddresses bool) Fetcher {
 	}
 }
 
-func (f *defaultFetcher) Fetch(name string, url string, header http.Header) (File, func(), error) {
-	return fetch(name, url, "", unknown, header, f.allowPrivateAddresses)
+func (f *defaultFetcher) Fetch(name string, src File) (File, func(), error) {
+	if remote, ok := src.(*RemoteFile); ok {
+		return fetch(name, remote.URL(), "", unknown, remote.Header(), f.allowPrivateAddresses)
+	}
+
+	return fetchArchive(name, src)
 }
 
 func (f *defaultFetcher) FetchFile(name string, url string, header http.Header) (File, func(), error) {

--- a/pkg/file/remote.go
+++ b/pkg/file/remote.go
@@ -1,0 +1,65 @@
+package file
+
+import (
+	"fmt"
+	"io/fs"
+	"net/http"
+	"path"
+	"time"
+)
+
+// RemoteFile is a File that references content located at a URL. It is a marker
+// that a Fetcher resolves by downloading; its contents cannot be read directly,
+// so any attempt to read or seek it before fetching returns an error.
+type RemoteFile struct {
+	url    string
+	header http.Header
+}
+
+// NewRemoteFile creates a RemoteFile for the given URL and optional request
+// headers.
+func NewRemoteFile(url string, header http.Header) *RemoteFile {
+	return &RemoteFile{
+		url:    url,
+		header: header,
+	}
+}
+
+// URL returns the source URL of the remote file.
+func (f *RemoteFile) URL() string {
+	return f.url
+}
+
+// Header returns the request headers to use when fetching the remote file.
+func (f *RemoteFile) Header() http.Header {
+	return f.header
+}
+
+func (f *RemoteFile) Name() string {
+	return path.Base(f.url)
+}
+
+func (f *RemoteFile) Read([]byte) (int, error) {
+	return 0, fmt.Errorf("%w: a remote file must be fetched before it can be read", ErrSystemFailure)
+}
+
+func (f *RemoteFile) Seek(int64, int) (int64, error) {
+	return 0, fmt.Errorf("%w: a remote file must be fetched before it can be seeked", ErrSystemFailure)
+}
+
+func (f *RemoteFile) Close() error {
+	return nil
+}
+
+func (f *RemoteFile) Stat() (fs.FileInfo, error) {
+	return f.Metadata(), nil
+}
+
+func (f *RemoteFile) Metadata() fs.FileInfo {
+	return &BufferFileInfo{
+		name:    f.Name(),
+		size:    0,
+		mode:    0644,
+		modTime: time.Now(),
+	}
+}


### PR DESCRIPTION
This PR fixes the module file-upload endpoint, which broke after the file getter was removed, and reworks how the module service receives its source so it no longer depends on the file:// scheme.

The file-upload endpoint used to save the upload to a temp file and hand the service a file:// URL so it could reuse the same go-getter fetch path as URL-based registration. Once the file getter was dropped (to close the arbitrary-file-read vector), go-getter could no longer resolve file://, so every file upload failed.

## What's Changed

- Added `file.RemoteFile`, a `file.File` that carries a URL and request headers. The `Fetcher` resolves a `RemoteFile` by downloading it through go-getter (still with no local-file scheme), and treats any other `file.File` as an uploaded archive, decompressing it locally with go-getter's decompressors.
- Replaced the module service's `Upload(dto, url, header)` with a single `Upload(dto, file.File)`. The URL endpoint passes a `RemoteFile`; the file-upload endpoint streams the uploaded archive directly, with no temp file or file:// URI.
- Uploading module files now requires a storage resolver and returns a clear error in proxy mode, instead of recording a dead file:// location pointing at a deleted temp file.
- Added a service test that exercises the upload path with the real fetcher, and an e2e multipart upload test. The regression slipped through because the only happy-path upload test used the remote `download_url` flow and the service test mocked the fetcher.

Closes #854.