### PR TITLE
Pin unpinned-action references across 5 workflows

### DIFF
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,16 +27,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Set the commit hash
       run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -45,7 +45,7 @@ jobs:
       run: echo "BUILD_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S")" >> $GITHUB_ENV
 
     - name: Login to Packages Container registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -84,7 +84,7 @@ jobs:
 
     - name: Build and push
       if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) }}
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         platforms: linux/arm64,linux/amd64

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Configure Git Credentials
         run: |
@@ -26,11 +26,11 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           key: ${{ runner.os }}-mkdocs-material
           path: .cache

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     if: (!contains(github.ref, '-pre.'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
@@ -49,7 +49,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -61,7 +61,7 @@ jobs:
         run: echo "BUILD_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S")" >> $GITHUB_ENV
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "24"
           cache: "yarn"
@@ -69,7 +69,7 @@ jobs:
             web/yarn.lock
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: "1.26"
           cache-dependency-path: |
@@ -90,7 +90,7 @@ jobs:
         run: touch web/dist/.gitkeep
 
       - name: Release stable
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89
         if: (!contains(github.ref, '-pre.'))
         with:
           version: v2.4.8
@@ -113,7 +113,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Release pre-release
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89
         if: contains(github.ref, '-pre.')
         with:
           version: v2.4.8

--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -20,16 +20,16 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Set the commit hash
       id: commit-hash
@@ -40,14 +40,14 @@ jobs:
       run: echo "BUILD_TIMESTAMP=$(date +"%Y%m%d%H%M%S")" >> $GITHUB_OUTPUT
 
     - name: Login to Packages Container registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         file: Dockerfile.test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: "1.26"
           cache-dependency-path: |
@@ -33,7 +33,7 @@ jobs:
             tools/go.sum
 
       - name: Install task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
 
       - name: Install dependencies
         run: task --verbose tidy
@@ -54,7 +54,7 @@ jobs:
         run: task --verbose test:unit -- --cover
 
       - name: Upload unit test coverage
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: coverage-unit
           path: coverage/unit.txt
@@ -68,10 +68,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Cache Go Packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             ~/.cache/go-build
@@ -81,7 +81,7 @@ jobs:
             go-${{ runner.os }}-${{ runner.arch }}-
 
       - name: Cache Yarn Packages
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           path: |
             web/node_modules
@@ -103,7 +103,7 @@ jobs:
         run: task --verbose build:backend -- --release --cover
 
       - name: Save binary
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: terralist
           path: terralist
@@ -228,7 +228,7 @@ jobs:
 
     steps:
       - name: Download terralist binary
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: terralist
           path: /usr/local/bin/terralist
@@ -239,7 +239,7 @@ jobs:
           echo "PATH=$PATH:/usr/local/bin/terralist" >> $GITHUB_ENV
 
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Generate TLS certificate
         run: |
@@ -313,7 +313,7 @@ jobs:
 
       - name: Upload e2e coverage
         if: always() && matrix.database-backend == 'sqlite'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: coverage-e2e
           path: coverage/e2e/
@@ -321,7 +321,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: e2e-reports-${{ matrix.database-backend }}
           path: |
@@ -339,19 +339,19 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Mark repo clone as safe
         run: git config --global --add safe.directory /__w/terralist/terralist
 
       - name: Download unit test coverage
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: coverage-unit
           path: coverage/
 
       - name: Download e2e coverage
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131
         with:
           name: coverage-e2e
           path: coverage/e2e/


### PR DESCRIPTION
> 🤖 An AI-generated pull request from [codeopsai](https://codeopsai.com). We open PRs only when we find a concrete, citable issue worth fixing. Not useful? Comment **"no thanks"** and we won't open more.

<details>
<summary>About codeopsai</summary>

codeopsai analyzes public GitHub Actions workflows for security and reliability issues and opens fixes for maintainer review. Every PR carries citations to the relevant standard (CWE, GitHub docs) and a structural verification trail; if our evidence bar isn't met, we don't open the PR.

**Mistake, or unwelcome?** Comment here or open an issue at [github.com/codeopsai/feedback](https://github.com/codeopsai/feedback). We read every one and adjust.
</details>

## Why these matter

**Why pin to a SHA** (`unpinned-action`)

Each unpinned action reference can be force-moved to attacker-controlled code by the action's owner or anyone who compromises their account — exactly what happened in the tj-actions/changed-files attack (CVE-2025-30066, Mar 2025). Pinning to a 40-character commit SHA freezes the exact reviewed code.

Reference: CWE-829 · [GitHub/OWASP guidance](https://docs.github.com/en/actions/reference/security/secure-use) · Real-world precedent: tj-actions/changed-files supply-chain attack (CVE-2025-30066, Mar 2025)

### `.github/workflows/image.yml`

- 🟠 MED `docker/setup-qemu-action` (job `build`)
- 🟠 MED `docker/setup-buildx-action` (job `build`)
- 🟠 MED `docker/login-action` (job `build`)
- 🟠 MED `docker/build-push-action` (job `build`)
- ⚪ LOW `actions/checkout` (job `build`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/image.yml
+++ b/.github/workflows/image.yml
@@ -27,16 +27,16 @@
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Set the commit hash
       run: echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
@@ -45,7 +45,7 @@
       run: echo "BUILD_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S")" >> $GITHUB_ENV
 
     - name: Login to Packages Container registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
@@ -84,7 +84,7 @@
 
     - name: Build and push
       if: ${{ contains(fromJson('["push", "pull_request", "workflow_dispatch"]'), github.event_name) }}
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         platforms: linux/arm64,linux/amd64
```

</details>

### `.github/workflows/publish-docs.yml`

- ⚪ LOW `actions/checkout` (job `deploy`)
- ⚪ LOW `actions/setup-python` (job `deploy`)
- ⚪ LOW `actions/cache` (job `deploy`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -18,7 +18,7 @@
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Configure Git Credentials
         run: |
@@ -26,11 +26,11 @@
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
-      - uses: actions/cache@v5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
         with:
           key: ${{ runner.os }}-mkdocs-material
           path: .cache
```

</details>

### `.github/workflows/release.yml`

- 🟠 MED `goreleaser/goreleaser-action` (job `goreleaser`)
- 🟠 MED `goreleaser/goreleaser-action` (job `goreleaser`)
- ⚪ LOW `actions/checkout` (job `publish-docs`)
- ⚪ LOW `actions/setup-python` (job `publish-docs`)
- ⚪ LOW `actions/checkout` (job `goreleaser`)
- ⚪ LOW `actions/setup-node` (job `goreleaser`)
- ⚪ LOW `actions/setup-go` (job `goreleaser`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@
     if: (!contains(github.ref, '-pre.'))
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
         with:
           fetch-depth: 0
 
@@ -28,7 +28,7 @@
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
 
       - name: Install Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: 3.x
 
@@ -49,7 +49,7 @@
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Set release version
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
@@ -61,7 +61,7 @@
         run: echo "BUILD_TIMESTAMP=$(date +"%Y-%m-%dT%H:%M:%S")" >> $GITHUB_ENV
 
       - name: Set up Node
-        uses: actions/setup-node@v5
+        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444
         with:
           node-version: "24"
           cache: "yarn"
@@ -69,7 +69,7 @@
             web/yarn.lock
... (25 more diff lines — see Files changed)
```

</details>

### `.github/workflows/test-image.yml`

- 🟠 MED `docker/setup-qemu-action` (job `build`)
- 🟠 MED `docker/setup-buildx-action` (job `build`)
- 🟠 MED `docker/login-action` (job `build`)
- 🟠 MED `docker/build-push-action` (job `build`)
- ⚪ LOW `actions/checkout` (job `build`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/test-image.yml
+++ b/.github/workflows/test-image.yml
@@ -20,16 +20,16 @@
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v5
+      uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v4
+      uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3
       with:
         image: tonistiigi/binfmt:latest
         platforms: arm64,arm
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v4
+      uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5
 
     - name: Set the commit hash
       id: commit-hash
@@ -40,14 +40,14 @@
       run: echo "BUILD_TIMESTAMP=$(date +"%Y%m%d%H%M%S")" >> $GITHUB_OUTPUT
 
     - name: Login to Packages Container registry
-      uses: docker/login-action@v4
+      uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push
-      uses: docker/build-push-action@v7
+      uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf
       with:
         context: .
         file: Dockerfile.test
```

</details>

### `.github/workflows/test.yml`

- 🟠 MED `go-task/setup-task` (job `unit-test`)
- ⚪ LOW `actions/checkout` (job `unit-test`)
- ⚪ LOW `actions/setup-go` (job `unit-test`)
- ⚪ LOW `actions/upload-artifact` (job `unit-test`)
- ⚪ LOW `actions/checkout` (job `build-terralist-binary`)
- ⚪ LOW `actions/cache` (job `build-terralist-binary`)
- ⚪ LOW `actions/cache` (job `build-terralist-binary`)
- ⚪ LOW `actions/upload-artifact` (job `build-terralist-binary`)
- ⚪ LOW `actions/download-artifact` (job `e2e-tests`)
- ⚪ LOW `actions/checkout` (job `e2e-tests`)
- ⚪ LOW `actions/upload-artifact` (job `e2e-tests`)
- ⚪ LOW `actions/upload-artifact` (job `e2e-tests`)
- ⚪ LOW `actions/checkout` (job `coverage-report`)
- ⚪ LOW `actions/download-artifact` (job `coverage-report`)
- ⚪ LOW `actions/download-artifact` (job `coverage-report`)

<details>
<summary>Diff</summary>

```diff
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
         with:
           go-version: "1.26"
           cache-dependency-path: |
@@ -33,7 +33,7 @@
             tools/go.sum
 
       - name: Install task
-        uses: go-task/setup-task@v2
+        uses: go-task/setup-task@01a4adf9db2d14c1de7a560f09170b6e0df736aa
 
       - name: Install dependencies
         run: task --verbose tidy
@@ -54,7 +54,7 @@
         run: task --verbose test:unit -- --cover
 
       - name: Upload unit test coverage
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: coverage-unit
           path: coverage/unit.txt
@@ -68,10 +68,10 @@
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
 
... (83 more diff lines — see Files changed)
```

</details>


---

_Have other repositories you'd like analysed? Request a scan at [codeopsai.com](https://codeopsai.com)._

---

_AI-generated. Review the diff before merging._
