### PR TITLE
fix(docs): reference groups with role: prefix

### DIFF
--- a/docs/user-guide/rbac-configuration.md
+++ b/docs/user-guide/rbac-configuration.md
@@ -31,9 +31,9 @@ The model syntax is based on [Casbin](https://casbin.org/docs/overview) and high
 
 **Group**: Used to assign users or groups to internal roles.
 
-Syntax: `g, <username/useremail/group>, <role>`
+Syntax: `g, <username>/<useremail>/role:<group>, <role>`
 
-- `<username/useremail/group>`: The entity to whom the role will be assigned. Depending on the OAuth provider implementation those values can represent different things; Usually, the `username` refers to the `sub` claim, while the `useremail` and `group` refers to a custom claims, which might not even be supported by the provider you are using. Check the OAuth provider documentation for more details.
+- `<username>/<useremail>/role:<group>`: The entity to whom the role will be assigned. Depending on the OAuth provider implementation those values can represent different things; Usually, the `username` refers to the `sub` claim, while the `useremail` and `group` refers to a custom claims, which might not even be supported by the provider you are using. Check the OAuth provider documentation for more details.
 - `<role>`: The internal role to which the entity will be assigned.
 
 <!-- TODO: Add proper oauth provider docs -->
@@ -49,9 +49,9 @@ Below is a table that defines claims meaning for each OAuth provider.
 
 **Policy**: Allows to assign permissions to an entity.
 
-Syntax: `p, <role/username/useremail/group>, <resource>, <action>, <object>, <effect>`
+Syntax: `p, role:<role>/<username>/<useremail>/role:<group>, <resource>, <action>, <object>, <effect>`
 
-- `<role/username/useremail/group>`: The entity to whom the policy will be assigned
+- `role:<role>/<username>/<useremail>/role:<group>`: The entity to whom the policy will be assigned
 - `<resource>`<sup>*</sup>: The type of resource on which the action is performed. Can be one of: `modules`, `providers`, `authorities`, `api-keys`, `settings`. Supports glob matching.
 - `<action>`<sup>*</sup>: The operation that is being performed on the resource. Can be one of: `get`, `create`, `update`, `delete`. Supports glob matching.
 - `<object>`<sup>*</sup>: The object identifier representing the resource on which the action is performed. Supports glob matching. Depending on the resource, the object's format will vary.
@@ -129,8 +129,8 @@ p, role:authority-admin, authorities, *, *, allow
 Then map identity claims (user/group/email) to those roles:
 
 ```csv
-g, SSOAWS_PLATFORM, role:authority-admin
-g, SSOAWS_ENGINEERING, role:authority-reader
+g, role:SSOAWS_PLATFORM, role:authority-admin
+g, role:SSOAWS_ENGINEERING, role:authority-reader
 ```
 
 ## Settings Page Access With RBAC


### PR DESCRIPTION
This PR fixes the RBAC documentation to show that group names must be referenced with the `role:` prefix in policy and role mappings.

Closes #880.